### PR TITLE
Feat: public library page (issue #38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,10 @@ gh pr create --title "..." --body "..."
 # CI runs; merge when green
 ```
 
+PR descriptions must include:
+1. **What problem or enhancement this addresses** — reference the issue number when one exists (e.g. "Closes #38")
+2. **A brief summary of the approach** — the key design choices made and why, so the diff can be understood in context
+
 ## Development Tips
 
 - **Local full-stack**: `docker compose up --build` — `docker-compose.override.yml` is automatically applied and handles local differences (HTTP-only nginx, certbot disabled, `SERVER_HOSTNAME=localhost`)

--- a/frontend/library.html
+++ b/frontend/library.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Library</title>
+  <link rel="stylesheet" href="/static/style.css" />
+  <script defer src="/static/alpinejs-3.15.8.min.js"></script>
+</head>
+<body>
+  <script src="/static/nav.js"></script>
+
+  <div class="container" x-data="libraryPage()" x-init="init()">
+    <h1>Station Library</h1>
+    <p class="subtitle">All songs in the station, grouped by who added them.</p>
+
+    <div x-show="loading" class="empty-state">Loading…</div>
+    <div x-show="!loading && tracks.length === 0" class="empty-state">No tracks in the library yet.</div>
+
+    <template x-for="[submitter, submitterTracks] in bySubmitter" :key="submitter">
+      <div class="card">
+        <h2 x-text="`${submitter} (${submitterTracks.length})`"></h2>
+        <template x-for="track in submitterTracks" :key="track.id">
+          <div class="track-item">
+            <div class="track-meta">
+              <div class="track-title" x-text="track.title"></div>
+              <div class="track-sub" x-text="track.artist"></div>
+            </div>
+            <div style="text-align:right; font-size:0.8rem; color:var(--muted); flex-shrink:0;">
+              <div x-text="formatDate(track.submitted_at)"></div>
+              <div x-text="track.play_count === 1 ? '1 play' : track.play_count + ' plays'"></div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </template>
+  </div>
+
+  <script>
+    function libraryPage() {
+      return {
+        tracks: [],
+        loading: true,
+
+        get bySubmitter() {
+          const groups = {};
+          for (const t of this.tracks) {
+            if (!groups[t.submitter]) groups[t.submitter] = [];
+            groups[t.submitter].push(t);
+          }
+          return Object.entries(groups).sort((a, b) => a[0].localeCompare(b[0]));
+        },
+
+        async init() {
+          try {
+            const res = await fetch('/api/public-library');
+            const data = await res.json();
+            this.tracks = data.tracks;
+          } catch { /* ignore */ }
+          this.loading = false;
+        },
+
+        formatDate(iso) {
+          return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+        },
+      };
+    }
+  </script>
+</body>
+</html>

--- a/frontend/static/nav.js
+++ b/frontend/static/nav.js
@@ -3,6 +3,7 @@
   var links = [
     { href: '/', label: 'Submit' },
     { href: '/playing.html', label: 'Now Playing' },
+    { href: '/library.html', label: 'Library' },
     { href: '/admin.html', label: 'Admin' },
   ];
   var items = links.map(function (l) {


### PR DESCRIPTION
## What this addresses

Closes #38 (the public library view half — duplicate detection was addressed in #39).

Submitters had no way to browse what songs are already in the station before submitting, which contributed to duplicate submissions and made it impossible to know if a song you wanted to add was already there.

## Approach

**Backend**: New `GET /public-library` endpoint in `status.py` that returns only `status='ready'` tracks (pending/failed tracks are excluded — they either don't have real titles yet or never made it in). Uses a single JOIN against `play_log` to include play counts. Results are ordered by submitter then title at the SQL level.

**Frontend**: New standalone `library.html` page following the same structure as `playing.html`. Tracks are grouped by submitter client-side using a computed getter, with each group rendered as a card. Each track shows title, artist, upload date, and play count.

**Nav**: Library link added to `nav.js` between Now Playing and Admin.

**CLAUDE.md**: Added PR description requirements (problem statement + approach summary).