### PR TITLE
Fix: hide volume slider on iOS (issue #46)

### DIFF
--- a/frontend/playing.html
+++ b/frontend/playing.html
@@ -34,7 +34,7 @@
         <button class="btn secondary" style="padding:0.3rem 0.8rem; font-size:0.8rem;" @click="backToLive()">↩ Back to Live</button>
       </span>
 
-      <div style="display:flex; align-items:center; gap:0.4rem; margin-left:auto;">
+      <div x-show="!isIos" style="display:flex; align-items:center; gap:0.4rem; margin-left:auto;">
         <span style="opacity:0.5; font-size:0.9rem; line-height:1;">🔈</span>
         <input type="range" min="0" max="1" step="0.05" x-model="volume" @input="setVolume()" style="width:80px; cursor:pointer;" />
         <span style="opacity:0.5; font-size:0.9rem; line-height:1;">🔊</span>
@@ -120,6 +120,7 @@
         everPlayed: false,
         userPaused: false,
         volume: 1,
+        isIos: /iphone|ipad|ipod/i.test(navigator.userAgent),
         pausedSeconds: 0,
         pausedTimer: null,
         pausedAt: null,


### PR DESCRIPTION
## What this addresses

Closes #46. The volume slider on the Now Playing page did nothing on iOS.

## Root cause

iOS Safari (and all browsers on iOS, which must use WebKit) ignores writes to `audio.volume`. Apple restricts volume control to hardware buttons only — this is an intentional platform restriction, not a bug.

## Approach

Detect iOS via `navigator.userAgent` (same pattern already used in `push.js` for the push notification install prompt) and hide the volume slider entirely. Users on iOS see no slider rather than a slider that appears to work but doesn't.

The change is two lines: an `isIos` data property on the Alpine component, and `x-show="!isIos"` on the volume slider `<div>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)