### PR TITLE
Feat: simplify player — Pause/Resume from Live (#41, #42)

### DIFF
--- a/frontend/playing.html
+++ b/frontend/playing.html
@@ -21,17 +21,12 @@
     <div class="card" style="display:flex; align-items:center; gap:1rem; flex-wrap:wrap;">
       <audio x-ref="audio" preload="none"></audio>
 
-      <button class="btn" style="font-size:1.1rem; min-width:7rem;" @click="togglePlay()">
-        <span x-text="playing ? '⏸ Pause' : '▶ Play'"></span>
+      <button class="btn" style="font-size:1.1rem; min-width:10rem;" @click="togglePlay()">
+        <span x-text="playing ? '⏸ Pause' : (everPlayed ? '▶ Resume from Live' : '▶ Play')"></span>
       </button>
 
-      <span x-show="playing && totalBehindMs === 0" class="live-indicator" x-cloak>
+      <span x-show="playing" class="live-indicator" x-cloak>
         <span class="live-dot"></span> LIVE
-      </span>
-
-      <span x-show="everPlayed && (totalBehindMs > 0 || pausedAt !== null)" style="display:inline-flex; align-items:center; gap:0.6rem; color:var(--muted); font-size:0.875rem;" x-cloak>
-        <span x-show="pausedSeconds > 0">~<span x-text="pausedSeconds"></span>s behind live</span>
-        <button class="btn secondary" style="padding:0.3rem 0.8rem; font-size:0.8rem;" @click="backToLive()">↩ Back to Live</button>
       </span>
 
       <div x-show="!isIos" style="display:flex; align-items:center; gap:0.4rem; margin-left:auto;">
@@ -118,13 +113,8 @@
         loaded: false,
         playing: false,
         everPlayed: false,
-        userPaused: false,
         volume: 1,
         isIos: /iphone|ipad|ipod/i.test(navigator.userAgent),
-        pausedSeconds: 0,
-        pausedTimer: null,
-        pausedAt: null,
-        totalBehindMs: 0,
         streamUrl: `${location.protocol}//${location.hostname}/stream`,
         pushSupported: false,
         pushNeedsInstall: false,
@@ -139,30 +129,12 @@
           audio.addEventListener('play', () => {
             this.playing = true;
             this.everPlayed = true;
-            if (this.userPaused && this.pausedAt !== null) {
-              this.totalBehindMs += Date.now() - this.pausedAt;
-              this.pausedAt = null;
-            }
-            this.userPaused = false;
-            if (this.pausedTimer) {
-              clearInterval(this.pausedTimer);
-              this.pausedTimer = null;
-            }
-            this.pausedSeconds = Math.floor(this.totalBehindMs / 1000);
+            sessionStorage.setItem('radioState', JSON.stringify({ active: true, paused: false }));
           });
 
           audio.addEventListener('pause', () => {
             this.playing = false;
-            // Ignore buffering stalls — only track user-initiated pauses.
-            if (!this.userPaused) return;
-            if (this.pausedTimer) {
-              clearInterval(this.pausedTimer);
-              this.pausedTimer = null;
-            }
-            this.pausedAt = Date.now();
-            this.pausedTimer = setInterval(() => {
-              this.pausedSeconds = Math.floor((this.totalBehindMs + Date.now() - this.pausedAt) / 1000);
-            }, 1000);
+            sessionStorage.setItem('radioState', JSON.stringify({ active: true, paused: true }));
           });
 
           audio.addEventListener('error', () => {
@@ -184,27 +156,11 @@
         togglePlay() {
           const audio = this.$refs.audio;
           if (this.playing) {
-            this.userPaused = true;
             audio.pause();
           } else {
-            if (!this.everPlayed) {
-              audio.src = `${this.streamUrl}?t=${Date.now()}`;
-            }
+            audio.src = `${this.streamUrl}?t=${Date.now()}`;
             audio.play().catch(() => {});
           }
-        },
-
-        backToLive() {
-          const audio = this.$refs.audio;
-          if (this.pausedTimer) {
-            clearInterval(this.pausedTimer);
-            this.pausedTimer = null;
-          }
-          this.pausedSeconds = 0;
-          this.totalBehindMs = 0;
-          this.pausedAt = null;
-          audio.src = `${this.streamUrl}?t=${Date.now()}`;
-          audio.play().catch(() => {});
         },
 
         setVolume() {


### PR DESCRIPTION
## What this addresses

Part 1 of the mobile PWA overhaul (#41, #42). Simplifies the audio player as a prerequisite for the persistent mini-player across pages.

## Problem

The "resume from where you left off" feature accumulated a behind-live timer while paused. This worked fine within a single page session, but doesn't survive navigation — the audio buffer is tied to the `<audio>` element and is destroyed when the page unloads. Building a persistent cross-page mini-player on top of this would be confusing (user is 30s behind on Now Playing, navigates to Library, mini-player rejoins live, user returns to Now Playing still showing 30s behind).

## Approach

Replace the behind-live model with a simpler Pause / Resume from Live:

- **Pause** stops the audio and stores `{ active: true, paused: true }` in sessionStorage
- **Resume from Live** always reconnects via a fresh `audio.src` assignment — no buffered position, always live
- Button label changes: `▶ Play` (first load) → `⏸ Pause` (playing) → `▶ Resume from Live` (paused)
- Removes `totalBehindMs`, `pausedAt`, `pausedTimer`, `pausedSeconds`, `userPaused`, and the `backToLive()` method
- The sessionStorage `radioState` key (`{ active, paused }`) is written here and will be read by the nav mini-player in a follow-up PR

## Follow-up PRs

- PR 2: Bottom tab bar on mobile
- PR 3: Persistent mini-player in nav.js reading sessionStorage
- PR 4: Media Session API + AirPlay button

🤖 Generated with [Claude Code](https://claude.com/claude-code)