### PR TITLE
Fix: show Connecting… state while audio buffers (#41)

### DIFF
--- a/frontend/playing.html
+++ b/frontend/playing.html
@@ -19,10 +19,11 @@
 
     <!-- Player -->
     <div class="card" style="display:flex; align-items:center; gap:1rem; flex-wrap:wrap;">
-      <audio x-ref="audio" preload="none"></audio>
+      <audio x-ref="audio" preload="auto"></audio>
 
-      <button class="btn" style="font-size:1.1rem; min-width:10rem;" @click="togglePlay()">
-        <span x-text="playing ? '⏸ Pause' : (everPlayed ? '▶ Resume from Live' : '▶ Play')"></span>
+      <button class="btn" style="font-size:1.1rem; min-width:10rem;" @click="togglePlay()" :disabled="loading">
+        <span x-show="loading" class="spinner"></span>
+        <span x-text="loading ? 'Connecting…' : (playing ? '⏸ Pause' : (everPlayed ? '▶ Resume from Live' : '▶ Play'))"></span>
       </button>
 
       <span x-show="playing" class="live-indicator" x-cloak>
@@ -112,6 +113,7 @@
         pendingCount: 0,
         loaded: false,
         playing: false,
+        loading: false,
         everPlayed: false,
         volume: 1,
         isIos: /iphone|ipad|ipod/i.test(navigator.userAgent),
@@ -125,20 +127,31 @@
         async init() {
           const audio = this.$refs.audio;
           audio.volume = this.volume;
+          audio.src = this.streamUrl;
 
           audio.addEventListener('play', () => {
-            this.playing = true;
             this.everPlayed = true;
             sessionStorage.setItem('radioState', JSON.stringify({ active: true, paused: false }));
           });
 
+          audio.addEventListener('playing', () => {
+            this.playing = true;
+            this.loading = false;
+          });
+
+          audio.addEventListener('waiting', () => {
+            this.loading = true;
+          });
+
           audio.addEventListener('pause', () => {
             this.playing = false;
+            this.loading = false;
             sessionStorage.setItem('radioState', JSON.stringify({ active: true, paused: true }));
           });
 
           audio.addEventListener('error', () => {
             this.playing = false;
+            this.loading = false;
           });
 
           await this.refresh();
@@ -158,8 +171,12 @@
           if (this.playing) {
             audio.pause();
           } else {
-            audio.src = `${this.streamUrl}?t=${Date.now()}`;
-            audio.play().catch(() => {});
+            this.loading = true;
+            if (this.everPlayed) {
+              // Resume: reconnect to get current live point, discarding buffered audio
+              audio.src = `${this.streamUrl}?t=${Date.now()}`;
+            }
+            audio.play().catch(() => { this.loading = false; });
           }
         },
 


### PR DESCRIPTION
## What this addresses

Part of #41. Investigated a ~5 second delay between pressing Play/Resume and audio starting on Chrome for Android (both PWA and regular browser). Firefox on Android does not have this delay.

## Root cause

Chrome on Android has a multi-second gap between `audio.play()` being called and audio actually reaching the speaker. The `play` event fires immediately (intent to play), but the `playing` event fires only when audio is genuinely outputting sound. The old code used `play` to set the playing state, meaning the UI showed "LIVE" while the user heard nothing.

This appears to be Chrome's audio pipeline behaviour on Android and cannot be eliminated in JS.

## Approach

- Use the `playing` event (not `play`) to set `playing = true` and clear the loading state
- Add a `loading` state that activates on button press and clears when audio actually starts
- The `waiting` event (mid-stream stall/rebuffering) also activates the loading state
- Button shows a spinner + "Connecting…" and is disabled while loading, so users know the app is working
- `preload="auto"` + `audio.src` set in `init()` pre-buffers on page load to reduce first-play latency

## Known limitation

The ~5s delay on Chrome/Android cannot be eliminated. This PR makes it visible rather than leaving users wondering if the app is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)