### PR TITLE
Feat: bottom tab bar on mobile (#41)

### DIFF
--- a/frontend/static/nav.js
+++ b/frontend/static/nav.js
@@ -1,14 +1,17 @@
 (function () {
   var path = location.pathname;
   var links = [
-    { href: '/', label: 'Submit' },
-    { href: '/playing.html', label: 'Now Playing' },
-    { href: '/library.html', label: 'Library' },
-    { href: '/admin.html', label: 'Admin' },
+    { href: '/', label: 'Submit', icon: '+' },
+    { href: '/playing.html', label: 'Now Playing', icon: '♪' },
+    { href: '/library.html', label: 'Library', icon: '≡' },
+    { href: '/admin.html', label: 'Admin', icon: '⚙' },
   ];
   var items = links.map(function (l) {
     var active = l.href === '/' ? path === '/' : path === l.href;
-    return '<a href="' + l.href + '"' + (active ? ' class="active"' : '') + '>' + l.label + '</a>';
+    return '<a href="' + l.href + '"' + (active ? ' class="active"' : '') + '>' +
+      '<span class="nav-icon">' + l.icon + '</span>' +
+      '<span class="nav-label">' + l.label + '</span>' +
+      '</a>';
   }).join('');
 
   var name = localStorage.getItem('station_name') || 'Radio';

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -49,6 +49,8 @@ nav a {
 
 nav a:hover, nav a.active { color: var(--text); }
 
+.nav-icon { display: none; }
+
 .container {
   max-width: 720px;
   margin: 0 auto;
@@ -263,4 +265,48 @@ button.btn.secondary:hover { background: #3a3d4a; }
 @media (max-width: 480px) {
   .container { padding: 1rem; }
   h1 { font-size: 1.4rem; }
+}
+
+@media (max-width: 640px) {
+  /* Switch top nav to fixed bottom tab bar */
+  nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: auto;
+    height: auto;
+    border-top: 1px solid var(--border);
+    border-bottom: none;
+    padding: 0;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    gap: 0;
+    z-index: 100;
+  }
+
+  nav .logo { display: none; }
+
+  nav a {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.5rem 0.25rem;
+    font-size: 0.65rem;
+    gap: 0.2rem;
+  }
+
+  nav a.active { color: var(--accent); }
+
+  .nav-icon {
+    display: block;
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  /* Pad body so content isn't hidden behind the tab bar */
+  body {
+    padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
+  }
 }


### PR DESCRIPTION
## What this addresses

Part of #41 (mobile UI overhaul). Replaces the crowded top nav on mobile with a fixed bottom tab bar — the standard navigation pattern for mobile apps.

## Approach

- On screens ≤640px: nav moves to `position: fixed; bottom: 0` with icon + label stacked vertically per tab, active tab in accent colour, logo hidden
- On desktop: nav is completely unchanged (icons are hidden via `display: none`, labels render as before)
- `env(safe-area-inset-bottom)` padding accounts for the iPhone home indicator
- `body` gets matching `padding-bottom` so page content isn't hidden behind the bar
- Icons are Unicode symbols (`+`, `♪`, `≡`, `⚙`) — no icon library needed

## Part of series

- ✅ PR #51 — player simplification (Pause/Resume from Live)
- ✅ PR #52 — Connecting… loading state
- ✅ This PR — bottom tab bar
- PR 3 — persistent mini-player in nav.js
- PR 4 — Media Session API + AirPlay button

🤖 Generated with [Claude Code](https://claude.com/claude-code)