### PR TITLE
Fix: mobile polish pass on Submit and Admin pages

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -22,7 +22,7 @@
       <h2>Admin Login</h2>
       <div class="form-group">
         <label>Admin Token</label>
-        <input type="text" x-model="tokenInput" placeholder="Bearer token" @keydown.enter="login()" />
+        <input type="password" x-model="tokenInput" placeholder="Admin token" @keydown.enter="login()" />
       </div>
       <div class="alert error" x-show="authError" x-cloak x-text="authError"></div>
       <button class="btn" @click="login()">Sign In</button>
@@ -84,7 +84,7 @@
           <span x-show="cookieStatus !== null && !cookieStatus.present"
                 style="color:var(--danger)">✗ No cookies — YouTube downloads will fail on AWS</span>
         </p>
-        <div style="display:flex; gap:0.75rem; align-items:center">
+        <div style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
           <input type="file" x-ref="cookieFile" accept=".txt" style="font-size:0.875rem" />
           <button class="btn" @click="uploadCookies()">Upload cookies.txt</button>
         </div>
@@ -108,8 +108,7 @@
                    x-text="track.error_msg"></div>
             </div>
             <span class="badge" :class="track.status" x-text="track.status"></span>
-            <button class="btn danger" style="padding:0.35rem 0.75rem; font-size:0.8rem"
-                    @click="deleteTrack(track.id)">✕</button>
+            <button class="btn danger btn-sm" @click="deleteTrack(track.id)">✕</button>
           </div>
         </template>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,8 +37,8 @@
         </template>
       </ul>
       <div style="display:flex; gap:0.5rem; flex-wrap:wrap;">
-        <button type="button" class="btn btn-sm" @click="submitAnyway = true; submitSong()">Submit anyway</button>
-        <button type="button" class="btn btn-sm btn-secondary" @click="duplicates = []; submitAnyway = false">Cancel</button>
+        <button type="button" class="btn" @click="submitAnyway = true; submitSong()">Submit anyway</button>
+        <button type="button" class="btn secondary" @click="duplicates = []; submitAnyway = false">Cancel</button>
       </div>
     </div>
 

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -150,6 +150,11 @@ button.btn.secondary {
 }
 button.btn.secondary:hover { background: #3a3d4a; }
 
+button.btn.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
 .alert {
   padding: 0.75rem 1rem;
   border-radius: var(--radius);
@@ -367,6 +372,9 @@ body.has-mini-player { padding-bottom: 56px; }
   body {
     padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
   }
+
+  /* Ensure small buttons still meet minimum touch target height */
+  button.btn.btn-sm { min-height: 44px; }
 
   /* Mini-player sits above the tab bar */
   .mini-player {


### PR DESCRIPTION
## Summary

Closes #41 — final mobile UX pass identifying and fixing four issues across the Submit and Admin pages.

- **Submit — duplicate warning buttons**: `btn-sm` and `btn-secondary` CSS classes don't exist; the Cancel button was styled identically to Submit Anyway (both primary blue). Fixed to use `btn` / `btn secondary` so they're visually distinct.
- **Admin — token input masking**: `type="text"` meant the admin token was visible in plaintext while typing. Changed to `type="password"`.
- **Admin — cookie upload row overflow**: `display:flex` with a file input and button side-by-side was cramped on narrow screens. Added `flex-wrap:wrap` so the Upload button drops below the file picker when needed.
- **Admin — delete button touch target**: inline `padding:0.35rem` produced ~28px tall buttons, below the 44px recommended touch target. Replaced inline style with a `btn-sm` CSS class; on mobile (`≤640px`) `btn-sm` gets `min-height:44px`.

## Test plan

- [ ] Submit: trigger a duplicate (submit the same song twice) — "Submit anyway" should be primary blue, "Cancel" should be grey
- [ ] Admin: type in the token field — characters should be masked (●●●)
- [ ] Admin on narrow screen: cookie upload row should stack (file picker on top, Upload button below)
- [ ] Admin on mobile: delete (✕) buttons should be comfortably tappable
- [ ] Admin on desktop: delete buttons should still be compact (not full-size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)