### PR TITLE
feat: add ty type checking to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,21 +8,43 @@ MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 
 ruff := uvx ruff@0.15.2
+ty := uvx ty@0.0.19
+venv := .venv
+
+# type-check deps: lightweight packages ty needs for import resolution
+# (excludes librosa and its heavy compiled transitive deps — suppressed inline)
+type_deps := fastapi==0.129.2 pydantic==2.12.5 'pywebpush>=2.0.0' aiofiles==24.1.0 numpy==1.26.4
+
+$(venv)/.installed: api/requirements.txt
+	uv venv $(venv) --python 3.12 -q
+	uv pip install --python $(venv)/bin/python -q $(type_deps)
+	@touch $@
+
+.PHONY: typecheck
+typecheck: $(venv)/.installed
+	$(ty) check --project api --python $(venv)
 
 .PHONY: ci
 ci:
 	$(ruff) check api/
 	$(ruff) format --check api/
+	$(MAKE) typecheck
 
 .PHONY: fix
 fix:
 	$(ruff) check --fix api/
 	$(ruff) format api/
 
+.PHONY: clean
+clean:
+	rm -rf $(venv)
+
 .PHONY: help
 help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  ci        Run all checks (ruff lint + format)"
-	@echo "  fix       Auto-fix lint and format issues"
+	@echo "  ci         Run all checks (ruff lint + format + ty typecheck)"
+	@echo "  typecheck  Run ty type checking"
+	@echo "  fix        Auto-fix lint and format issues"
+	@echo "  clean      Remove type-check venv"

--- a/api/audio.py
+++ b/api/audio.py
@@ -1,6 +1,6 @@
 import logging
 
-import librosa
+import librosa  # ty: ignore[unresolved-import]
 import numpy as np
 from models import AudioFeatures
 

--- a/api/main.py
+++ b/api/main.py
@@ -33,7 +33,7 @@ _hostname = os.environ.get("SERVER_HOSTNAME", "")
 _origins = [f"https://{_hostname}"] if _hostname else ["http://localhost", "http://localhost:8000"]
 
 app.add_middleware(
-    CORSMiddleware,
+    CORSMiddleware,  # ty: ignore[invalid-argument-type]
     allow_origins=_origins,
     allow_methods=["GET", "POST", "DELETE"],
     allow_headers=["Content-Type", "X-Admin-Token"],

--- a/api/routers/submit.py
+++ b/api/routers/submit.py
@@ -137,7 +137,7 @@ async def submit_track(
     title: str = Form(None),
     artist: str = Form(None),
     file: UploadFile = File(None),
-    comment: str = Form(None),
+    comment: str | None = Form(None),
 ):
     if not submitter or not submitter.strip():
         raise HTTPException(400, "submitter is required")
@@ -166,6 +166,7 @@ async def submit_track(
     track_id = str(uuid.uuid4())
 
     if has_file:
+        assert file is not None and file.filename is not None
         ext = os.path.splitext(file.filename)[1].lower()
         if ext not in ALLOWED_EXTENSIONS:
             raise HTTPException(400, f"Unsupported file type: {ext}")

--- a/api/scheduler.py
+++ b/api/scheduler.py
@@ -195,7 +195,7 @@ def _pick_rotation_track(depth: int = 0) -> dict | None:
     }
 
 
-def _pick_mood_track() -> str:
+def _pick_mood_track() -> dict | None:
     """Pick track with minimum Euclidean distance from the last played track."""
     # Get the last played track's features
     with db() as conn:

--- a/api/worker.py
+++ b/api/worker.py
@@ -105,9 +105,7 @@ def _process_job(job_id: int, track_id: str):
         if result.returncode == 0:
             import json
 
-            info = json.load(
-                result.stdout if hasattr(result.stdout, "read") else __import__("io").StringIO(result.stdout)
-            )
+            info = json.loads(result.stdout)
             for stream in info.get("streams", []):
                 if stream.get("codec_type") == "audio":
                     duration_s = float(stream.get("duration", 0)) or None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,7 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W"]
+
+[tool.ty.environment]
+python-version = "3.12"
+root = ["api"]


### PR DESCRIPTION
Closes https://github.com/linuxmaier/custom-radio/issues/30

## Problem

The codebase has 15 Python files under `api/` with no type checking. Several real type errors existed: wrong return type annotation on `_pick_mood_track()`, `comment` parameter typed `str` but assigned `None`, `json.load()` called on a string instead of `json.loads()`, and unguarded `file.filename` (which is `str | None`).

## Approach

**Fix real type errors:**
- `scheduler.py`: fix `_pick_mood_track()` return type from `-> str` to `-> dict | None`
- `submit.py`: fix `comment` type to `str | None`, add assertion narrowing `file.filename` before `splitext` calls
- `worker.py`: replace `json.load(...)` with `json.loads(result.stdout)` — `result.stdout` is always a string when `text=True`

**Suppress known unfixable issues:**
- `main.py`: `# ty: ignore[invalid-argument-type]` on CORSMiddleware (known starlette typing issue)
- `audio.py`: `# ty: ignore[unresolved-import]` on `import librosa` (heavy compiled deps not worth installing for CI)

**CI integration:**
- `pyproject.toml`: add `[tool.ty.environment]` config (python-version, root)
- `Makefile`: add `typecheck` target that creates a lightweight venv with uv (fastapi, pydantic, pywebpush, aiofiles, numpy — ~4s install), then runs `ty check`. Integrated into the existing `ci` target.

All three CI checks pass: ruff lint, ruff format, ty typecheck.