### PR TITLE
Add Biome linting and formatting for frontend JS/CSS/HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4
+        with:
+          node-version: 22
       - run: make ci

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ MAKEFLAGS += --no-builtin-variables
 
 ruff := uvx ruff@0.15.2
 ty := uvx ty@0.0.19
+biome := npx @biomejs/biome@2.4.4
 venv := .venv
 
 # type-check deps: lightweight packages ty needs for import resolution
@@ -29,11 +30,13 @@ ci:
 	$(ruff) check api/
 	$(ruff) format --check api/
 	$(MAKE) typecheck
+	$(biome) check frontend/
 
 .PHONY: fix
 fix:
 	$(ruff) check --fix api/
 	$(ruff) format api/
+	$(biome) check --fix frontend/
 
 .PHONY: clean
 clean:
@@ -44,7 +47,7 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  ci         Run all checks (ruff lint + format + ty typecheck)"
+	@echo "  ci         Run all checks (ruff lint + format, ty typecheck, biome lint + format)"
 	@echo "  typecheck  Run ty type checking"
 	@echo "  fix        Auto-fix lint and format issues"
 	@echo "  clean      Remove type-check venv"

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "frontend/**/*.html",
+      "frontend/**/*.js",
+      "!frontend/**/*.min.js",
+      "frontend/**/*.css"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    },
+    "globals": ["Alpine"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": {
+        "useButtonType": "off",
+        "useMediaCaption": "off",
+        "noSvgWithoutTitle": "off",
+        "useAnchorContent": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "off",
+        "noUnusedFunctionParameters": "off",
+        "noInnerDeclarations": "off"
+      },
+      "style": {
+        "useConst": "off",
+        "useTemplate": "off"
+      },
+      "suspicious": {
+        "noEmptyBlockStatements": "off"
+      },
+      "complexity": {
+        "useOptionalChain": "off",
+        "noImportantStyles": "off"
+      }
+    }
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -223,7 +223,6 @@
             </div>
           </div>
         </template>
-      </ul>
       </div>
 
       <div x-show="recent.length === 0 && loaded" class="empty-state" x-cloak>
@@ -394,9 +393,9 @@
   <script>
     // Timing wrapper: stamps all [radio] console output with HH:MM:SS.mmm.
     // Trade-off: DevTools shows this wrapper's line number, not the call site.
-    (function () {
+    ((() => {
       function _stamp(orig) {
-        return function (...args) {
+        return (...args) => {
           if (typeof args[0] === 'string' && args[0].startsWith('[radio]')) {
             args[0] = '[radio ' + new Date().toISOString().slice(11, 23) + ']' + args[0].slice(7);
           }
@@ -406,7 +405,7 @@
       console.log   = _stamp(console.log.bind(console));
       console.warn  = _stamp(console.warn.bind(console));
       console.error = _stamp(console.error.bind(console));
-    }());
+    })());
 
     function shell() {
       var _cachedPublicStream = localStorage.getItem('radioPublicStreamUrl') || '';
@@ -977,8 +976,8 @@
         },
 
         async setBlockSize(val) {
-          const n = parseInt(val);
-          if (isNaN(n) || n < 1 || n > 20) return;
+          const n = parseInt(val, 10);
+          if (Number.isNaN(n) || n < 1 || n > 20) return;
           const res = await this.apiPost('/api/admin/config', { rotation_tracks_per_block: n });
           if (res.ok) {
             this.config.rotation_tracks_per_block = n;

--- a/frontend/static/nav.js
+++ b/frontend/static/nav.js
@@ -1,34 +1,52 @@
-(function () {
+(() => {
   var hash = location.hash;
   var links = [
-    { href: '/#submit',  label: 'Submit',      icon: '+' },
-    { href: '/#playing', label: 'Now Playing',  icon: '♪' },
-    { href: '/#library', label: 'Library',      icon: '≡' },
-    { href: '/#admin',   label: 'Admin',        icon: '⚙' },
+    { href: '/#submit', label: 'Submit', icon: '+' },
+    { href: '/#playing', label: 'Now Playing', icon: '♪' },
+    { href: '/#library', label: 'Library', icon: '≡' },
+    { href: '/#admin', label: 'Admin', icon: '⚙' },
   ];
 
   function linkIsActive(linkHash) {
     return linkHash === hash || (hash === '' && linkHash === '#playing');
   }
 
-  var items = links.map(function (l) {
-    var linkHash = new URL(l.href, location.origin).hash;
-    var active = linkIsActive(linkHash);
-    return '<a href="' + l.href + '"' + (active ? ' class="active"' : '') + '>' +
-      '<span class="nav-icon">' + l.icon + '</span>' +
-      '<span class="nav-label">' + l.label + '</span>' +
-      '</a>';
-  }).join('');
+  var items = links
+    .map((l) => {
+      var linkHash = new URL(l.href, location.origin).hash;
+      var active = linkIsActive(linkHash);
+      return (
+        '<a href="' +
+        l.href +
+        '"' +
+        (active ? ' class="active"' : '') +
+        '>' +
+        '<span class="nav-icon">' +
+        l.icon +
+        '</span>' +
+        '<span class="nav-label">' +
+        l.label +
+        '</span>' +
+        '</a>'
+      );
+    })
+    .join('');
 
   var name = localStorage.getItem('station_name') || 'Radio';
   var script = document.currentScript || document.scripts[document.scripts.length - 1];
-  script.insertAdjacentHTML('beforebegin',
-    '<nav><a id="nav-logo" class="logo" href="/#playing"><img src="/static/badge-96.png" alt="" width="20" height="20" style="vertical-align:middle;margin-right:0.4em;"> ' + name + '</a>' + items + '</nav>');
+  script.insertAdjacentHTML(
+    'beforebegin',
+    '<nav><a id="nav-logo" class="logo" href="/#playing"><img src="/static/badge-96.png" alt="" width="20" height="20" style="vertical-align:middle;margin-right:0.4em;"> ' +
+      name +
+      '</a>' +
+      items +
+      '</nav>',
+  );
 
   // Update active link on hash navigation (SPA — no full page reload)
-  window.addEventListener('hashchange', function () {
+  window.addEventListener('hashchange', () => {
     var currentHash = location.hash;
-    document.querySelectorAll('nav a[href^="/#"]').forEach(function (a) {
+    document.querySelectorAll('nav a[href^="/#"]').forEach((a) => {
       var linkHash = new URL(a.href).hash;
       a.classList.toggle('active', linkHash === currentHash || (currentHash === '' && linkHash === '#playing'));
     });
@@ -36,12 +54,12 @@
 
   // Register service worker for PWA support
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js').catch(function () {});
+    navigator.serviceWorker.register('/sw.js').catch(() => {});
   }
 
   fetch('/api/status')
-    .then(function (r) { return r.json(); })
-    .then(function (data) {
+    .then((r) => r.json())
+    .then((data) => {
       var fetched = data.station_name || 'Radio';
       localStorage.setItem('station_name', fetched);
       var logo = document.getElementById('nav-logo');
@@ -53,10 +71,13 @@
       document.title = fetched + ' \u2014 ' + document.title;
       // Keep token stream URL in sync on every page load
       if (data.public_stream_url) {
-        localStorage.setItem('radioPublicStreamUrl', location.protocol + '//' + location.hostname + data.public_stream_url);
+        localStorage.setItem(
+          'radioPublicStreamUrl',
+          location.protocol + '//' + location.hostname + data.public_stream_url,
+        );
       } else {
         localStorage.removeItem('radioPublicStreamUrl');
       }
     })
-    .catch(function () {});
-}());
+    .catch(() => {});
+})();

--- a/frontend/static/push.js
+++ b/frontend/static/push.js
@@ -1,5 +1,5 @@
 /* Push notification helpers — exposes window.pushHelpers */
-(function () {
+(() => {
   function urlBase64ToUint8Array(base64String) {
     var padding = '='.repeat((4 - (base64String.length % 4)) % 4);
     var base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
@@ -19,8 +19,7 @@
   // 'android' if a native install prompt is available, or false otherwise.
   function needsInstall() {
     var isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
-    var isInStandaloneMode = window.matchMedia('(display-mode: standalone)').matches
-      || navigator.standalone === true;
+    var isInStandaloneMode = window.matchMedia('(display-mode: standalone)').matches || navigator.standalone === true;
     if (isIos && !isInStandaloneMode) return 'ios';
     return false;
   }
@@ -94,4 +93,4 @@
   }
 
   window.pushHelpers = { isSupported, needsInstall, isSubscribed, subscribe, unsubscribe };
-}());
+})();

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,5 +1,13 @@
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-[x-cloak] { display: none !important; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+[x-cloak] {
+  display: none !important;
+}
 
 :root {
   --bg: #0f1117;
@@ -48,9 +56,14 @@ nav a {
   transition: color 0.15s;
 }
 
-nav a:hover, nav a.active { color: var(--text); }
+nav a:hover,
+nav a.active {
+  color: var(--text);
+}
 
-.nav-icon { display: none; }
+.nav-icon {
+  display: none;
+}
 
 .container {
   max-width: 720px;
@@ -58,9 +71,20 @@ nav a:hover, nav a.active { color: var(--text); }
   padding: 2rem 1.5rem;
 }
 
-h1 { font-size: 1.8rem; font-weight: 700; margin-bottom: 0.5rem; }
-h2 { font-size: 1.3rem; font-weight: 600; margin-bottom: 1rem; }
-p.subtitle { color: var(--muted); margin-bottom: 2rem; }
+h1 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+p.subtitle {
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
 
 .card {
   background: var(--surface);
@@ -94,12 +118,16 @@ textarea {
   transition: border-color 0.15s;
 }
 
-input:focus, select:focus, textarea:focus {
+input:focus,
+select:focus,
+textarea:focus {
   outline: none;
   border-color: var(--accent);
 }
 
-.form-group { margin-bottom: 1.2rem; }
+.form-group {
+  margin-bottom: 1.2rem;
+}
 
 .tabs {
   display: flex;
@@ -118,7 +146,8 @@ input:focus, select:focus, textarea:focus {
   transition: all 0.15s;
 }
 
-.tab-btn.active, .tab-btn:hover {
+.tab-btn.active,
+.tab-btn:hover {
   background: var(--accent);
   border-color: var(--accent);
   color: #fff;
@@ -139,17 +168,28 @@ button.btn {
   transition: background 0.15s;
 }
 
-button.btn:hover { background: var(--accent-hover); }
-button.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+button.btn:hover {
+  background: var(--accent-hover);
+}
+button.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
-button.btn.danger { background: var(--danger); }
-button.btn.danger:hover { background: #dc2626; }
+button.btn.danger {
+  background: var(--danger);
+}
+button.btn.danger:hover {
+  background: #dc2626;
+}
 
 button.btn.secondary {
   background: var(--border);
   color: var(--text);
 }
-button.btn.secondary:hover { background: #3a3d4a; }
+button.btn.secondary:hover {
+  background: #3a3d4a;
+}
 
 button.btn.btn-sm {
   padding: 0.35rem 0.75rem;
@@ -163,9 +203,21 @@ button.btn.btn-sm {
   margin-bottom: 1rem;
 }
 
-.alert.success { background: #052e16; border: 1px solid #166534; color: var(--success); }
-.alert.warning { background: #1c1400; border: 1px solid #92400e; color: var(--warning); }
-.alert.error   { background: #1c0000; border: 1px solid #991b1b; color: var(--danger); }
+.alert.success {
+  background: #052e16;
+  border: 1px solid #166534;
+  color: var(--success);
+}
+.alert.warning {
+  background: #1c1400;
+  border: 1px solid #92400e;
+  color: var(--warning);
+}
+.alert.error {
+  background: #1c0000;
+  border: 1px solid #991b1b;
+  color: var(--danger);
+}
 
 .track-item {
   display: flex;
@@ -175,11 +227,24 @@ button.btn.btn-sm {
   border-bottom: 1px solid var(--border);
 }
 
-.track-item:last-child { border-bottom: none; }
+.track-item:last-child {
+  border-bottom: none;
+}
 
-.track-meta { flex: 1; min-width: 0; }
-.track-title { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.track-sub { font-size: 0.8rem; color: var(--muted); }
+.track-meta {
+  flex: 1;
+  min-width: 0;
+}
+.track-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.track-sub {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
 
 .badge {
   display: inline-block;
@@ -191,10 +256,22 @@ button.btn.btn-sm {
   letter-spacing: 0.04em;
 }
 
-.badge.ready    { background: #052e16; color: var(--success); }
-.badge.pending  { background: #1c1400; color: var(--warning); }
-.badge.processing { background: #1c1400; color: var(--warning); }
-.badge.failed   { background: #1c0000; color: var(--danger); }
+.badge.ready {
+  background: #052e16;
+  color: var(--success);
+}
+.badge.pending {
+  background: #1c1400;
+  color: var(--warning);
+}
+.badge.processing {
+  background: #1c1400;
+  color: var(--warning);
+}
+.badge.failed {
+  background: #1c0000;
+  color: var(--danger);
+}
 
 .now-playing {
   background: linear-gradient(135deg, #1a1d27 0%, #1e1b3a 100%);
@@ -219,7 +296,9 @@ button.btn.btn-sm {
   margin-bottom: 0.25rem;
 }
 
-.now-playing .artist { color: var(--muted); }
+.now-playing .artist {
+  color: var(--muted);
+}
 
 .mode-toggle {
   display: flex;
@@ -231,13 +310,17 @@ button.btn.btn-sm {
   display: inline-block;
   width: 1rem;
   height: 1rem;
-  border: 2px solid rgba(255,255,255,0.3);
+  border: 2px solid rgba(255, 255, 255, 0.3);
   border-top-color: #fff;
   border-radius: 50%;
   animation: spin 0.6s linear infinite;
 }
 
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 .live-indicator {
   display: inline-flex;
@@ -258,8 +341,13 @@ button.btn.btn-sm {
 }
 
 @keyframes livepulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 .empty-state {
@@ -322,15 +410,29 @@ button.btn.btn-sm {
   transition: background 0.15s;
 }
 
-.mini-btn:hover { background: var(--accent-hover); }
-.mini-btn.secondary { background: var(--border); color: var(--muted); }
-.mini-btn.secondary:hover { background: #3a3d4a; color: var(--text); }
+.mini-btn:hover {
+  background: var(--accent-hover);
+}
+.mini-btn.secondary {
+  background: var(--border);
+  color: var(--muted);
+}
+.mini-btn.secondary:hover {
+  background: #3a3d4a;
+  color: var(--text);
+}
 
-body.has-player-bar { padding-bottom: 56px; }
+body.has-player-bar {
+  padding-bottom: 56px;
+}
 
 @media (max-width: 480px) {
-  .container { padding: 1rem; }
-  h1 { font-size: 1.4rem; }
+  .container {
+    padding: 1rem;
+  }
+  h1 {
+    font-size: 1.4rem;
+  }
 }
 
 @media (max-width: 640px) {
@@ -350,7 +452,9 @@ body.has-player-bar { padding-bottom: 56px; }
     z-index: 100;
   }
 
-  nav .logo { display: none; }
+  nav .logo {
+    display: none;
+  }
 
   nav a {
     flex: 1;
@@ -363,7 +467,9 @@ body.has-player-bar { padding-bottom: 56px; }
     gap: 0.2rem;
   }
 
-  nav a.active { color: var(--accent); }
+  nav a.active {
+    color: var(--accent);
+  }
 
   .nav-icon {
     display: block;
@@ -377,7 +483,9 @@ body.has-player-bar { padding-bottom: 56px; }
   }
 
   /* Ensure small buttons still meet minimum touch target height */
-  button.btn.btn-sm { min-height: 44px; }
+  button.btn.btn-sm {
+    min-height: 44px;
+  }
 
   /* Player bar sits above the tab bar */
   .player-bar {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,14 +1,14 @@
 /* Service Worker — Family Radio PWA */
 
-self.addEventListener('install', function (e) {
+self.addEventListener('install', (e) => {
   self.skipWaiting();
 });
 
-self.addEventListener('activate', function (e) {
+self.addEventListener('activate', (e) => {
   e.waitUntil(self.clients.claim());
 });
 
-self.addEventListener('push', function (e) {
+self.addEventListener('push', (e) => {
   var data = {};
   try {
     data = e.data ? e.data.json() : {};
@@ -27,11 +27,11 @@ self.addEventListener('push', function (e) {
   e.waitUntil(self.registration.showNotification(title, options));
 });
 
-self.addEventListener('notificationclick', function (e) {
+self.addEventListener('notificationclick', (e) => {
   e.notification.close();
   var target = (e.notification.data && e.notification.data.url) || '/#playing';
   e.waitUntil(
-    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (clients) {
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
       for (var i = 0; i < clients.length; i++) {
         var c = clients[i];
         if ('focus' in c) {
@@ -40,6 +40,6 @@ self.addEventListener('notificationclick', function (e) {
         }
       }
       return self.clients.openWindow(target);
-    })
+    }),
   );
 });


### PR DESCRIPTION
## Problem

Frontend code (JS, CSS, HTML) had no automated lint or format checks. Style inconsistencies and minor bugs (e.g. `parseInt` without radix, `isNaN` instead of `Number.isNaN`) went uncaught.

## Approach

Add [Biome](https://biomejs.dev/) v2.4.4 as a frontend linter and formatter, running alongside the existing ruff + ty checks for Python.

### Configuration (`biome.json`)
- Scoped to `frontend/**/*.{html,js,css}`, excluding vendored `.min.js`
- Formatter: 2-space indent, 120 line width, single quotes for JS
- Linter: recommended rules enabled, with targeted overrides for Alpine.js patterns (e.g. `noUnusedVariables` off since Alpine `x-data` functions appear unused to static analysis)

### Code fixes applied by Biome
- `parseInt(val)` → `parseInt(val, 10)` (explicit radix)
- `isNaN(n)` → `Number.isNaN(n)` (stricter check)
- `function(){}()` → `(() => {})()` (arrow IIFEs)
- CSS formatting normalization
- Removed stray `</ul>` closing tag in `index.html`

### CI integration
- Added `biome check frontend/` to the `ci` Makefile target
- `make fix` runs `biome check --fix frontend/` for auto-fixing
- CI workflow installs Node.js via `actions/setup-node`