### PR TITLE
Fix: notification click caused full page reload, pausing playback

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -467,6 +467,14 @@
             this.pushNeedsInstall = ph.needsInstall();
             ph.isSubscribed().then(v => { this.pushSubscribed = v; });
           }
+
+          if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.addEventListener('message', (e) => {
+              if (e.data?.type === 'navigate') {
+                location.hash = new URL(e.data.url, location.origin).hash || '#';
+              }
+            });
+          }
         },
 
         _applyHash(hash) {

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -35,7 +35,7 @@ self.addEventListener('notificationclick', (e) => {
       for (var i = 0; i < clients.length; i++) {
         var c = clients[i];
         if ('focus' in c) {
-          if (c.navigate) c.navigate(target);
+          c.postMessage({ type: 'navigate', url: target });
           return c.focus();
         }
       }


### PR DESCRIPTION
## Summary

Closes #64

- `WindowClient.navigate()` in the `notificationclick` service worker handler triggers a full page reload on Android Chrome even when the URL differs only by hash — resetting the console and interrupting active audio playback
- Replaced `c.navigate(target)` with `c.postMessage({ type: 'navigate', url: target })` in `sw.js`
- Added a `serviceWorker` `message` listener in `index.html` `init()` that updates `location.hash` directly, which fires the existing Alpine `hashchange` → `_applyHash()` flow without any page reload

## Test plan

- [ ] With the PWA open and audio playing, tap a push notification
- [ ] Verify the app navigates to Now Playing without pausing playback
- [ ] Verify the browser console does not reset on notification tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)