### PR TITLE
Feat: refresh library and admin data on each navigation

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1421,9 +1421,8 @@
         },
 
         async loadTracks() {
-          if (this._loaded) return;
+          if (!this._loaded) this.loading = true;
           this._loaded = true;
-          this.loading = true;
           try {
             const res = await fetch('/api/public-library');
             const data = await res.json();
@@ -1478,7 +1477,10 @@
         },
 
         async loadAdmin() {
-          if (this._loaded) return;
+          if (this._loaded) {
+            if (this.authed) await Promise.all([this.loadLibrary(), this.loadUsers()]);
+            return;
+          }
           this._loaded = true;
           if (this.tokenInput) {
             await this.login();


### PR DESCRIPTION
## Summary
- Removes the load-once guard from `libraryView.loadTracks()` and `adminView.loadAdmin()` so data re-fetches every time the user navigates to those views
- Library: spinner only on first load; re-navigations silently swap in fresh data
- Admin: if already authed, refreshes tracks + users on re-navigation; skips the login flow and leaves config/cookie status alone

Closes #67

## Test plan
- [ ] Navigate to Library, back to Now Playing, back to Library — track list refreshes silently (no spinner)
- [ ] Navigate to Admin, back, return to Admin — track list and user list refresh; admin token prompt does not reappear
- [ ] Verify audio playback and active Chromecast session are unaffected by navigating between views

🤖 Generated with [Claude Code](https://claude.com/claude-code)