### PR TITLE
Feat: Web Share Target API (Android share sheet)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,12 +107,19 @@ The frontend is a single-page app (`frontend/index.html`) using Alpine.js v3 wit
 - `user` — `{id, email, name}` or `null`; `authChecked` — `false` until `GET /api/auth/me` resolves (prevents flash of unauthed content)
 - `loginState` — `'email'` | `'pending'` | `'code'`; `loginEmail`, `loginMsg`, `loginError`, `loginBusy`, `claimCode`
 - `setupName`, `setupError`, `setupBusy` — for display-name-setup view shown on first login; `claimableNames: []` — populated by `GET /api/auth/claimable-names` when setup view appears; allows existing submitters to reclaim their track history by picking their name
+- `shareUrl` — YouTube URL captured from Android Web Share Target query params (`?url=` or `?text=`); set synchronously in `init()` before the auth fetch, cleared by `initSubmit()` after pre-filling the form
 
 **Auth flow in `init()`:**
 - `init()` is `async`; `_initRunning` guard at the top prevents double-execution (Alpine calls `init()` twice: once for the `init` method on the data object, once for `x-init="init()"` on `<body>`)
+- Immediately after the guard, query params are parsed for Web Share Target: `_extractYouTubeUrl()` checks `?url=` then `?text=`, stores any match in `this.shareUrl`, and calls `history.replaceState` to clean the URL — all synchronously, before the auth fetch
 - First action: `GET /api/auth/me` — 200 → set `user`, proceed normally; 401 → set `view = 'login'`
+- After auth succeeds, if `shareUrl` is set: `view = 'submit'` (overrides `_applyHash`). Same logic in `_routeToApp()` (called after passkey/magic-link sign-in).
 - `_applyHash()` forces `view = 'login'` if `!this.user`
 - `refresh()` (status poller) handles 401 by clearing `user` and setting `view = 'login'`
+
+**Web Share Target (`initSubmit()`):**
+- The manifest (`/api/manifest.json`) includes `share_target` with `action: "/"`, `method: "GET"`, params `title`/`text`/`url`. Android adds the PWA to the OS share sheet; sharing a YouTube URL opens `/?url=...` or `/?text=...`.
+- `initSubmit()` uses `$watch('view', ...)` to pre-fill the form when `view` transitions to `'submit'`. Do NOT change this to `$watch('shareUrl', ...)` or an immediate apply — Alpine initialises child `x-data` components (including `submitView`) while `init()` is suspended at `await fetch('/api/auth/me')`, so `initSubmit()` runs before the auth check completes. Clearing `shareUrl` immediately would prevent the auth-success branch from seeing it and navigating to the submit view.
 
 **Views added by auth:**
 - `login` — three states: email entry → `POST /api/auth/request-access` (approved users get magic link; others see pending message); code entry → `POST /api/auth/claim` → cookie set, `needs_name` check. Passkey users can sign in without email via the passkey flow (no code needed).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The frontend is a single-page app — navigation between views does not reload t
 | View | URL | Purpose |
 |------|-----|---------|
 | Now Playing | `/` or `/#playing` | See what's on, recent history, and manage push notifications |
-| Submit | `/#submit` | Add a song (file upload or YouTube link) |
+| Submit | `/#submit` | Add a song (file upload or YouTube link); on Android, the app appears in the OS share sheet so YouTube URLs can be shared directly into this view |
 | Library | `/#library` | All songs grouped by submitter with play counts |
 | Admin | `/#admin` | Change mode, skip track, manage library |
 
@@ -166,7 +166,7 @@ All public endpoints are proxied through nginx at `/api/`.
 | `GET` | `/api/library` | All tracks with status (admin use) |
 | `GET` | `/api/track/{id}` | Single track (for polling submission status) |
 | `GET` | `/api/check-duplicate` | Fuzzy duplicate check by `title`, `artist`, and/or `video_id` |
-| `GET` | `/api/manifest.json` | PWA Web App Manifest (station name from `STATION_NAME` env var) |
+| `GET` | `/api/manifest.json` | PWA Web App Manifest (station name from `STATION_NAME` env var); includes `share_target` so the PWA appears in the Android OS share sheet |
 | `GET` | `/api/push/vapid-key` | VAPID public key for push subscription |
 | `POST` | `/api/push/subscribe` | Register a push subscription (session-required in App Auth mode) |
 | `POST` | `/api/push/unsubscribe` | Remove a push subscription (session-required in App Auth mode) |

--- a/api/routers/push.py
+++ b/api/routers/push.py
@@ -47,6 +47,15 @@ def get_manifest():
                 "purpose": "monochrome",
             },
         ],
+        "share_target": {
+            "action": "/",
+            "method": "GET",
+            "params": {
+                "title": "title",
+                "text": "text",
+                "url": "url",
+            },
+        },
     }
     return JSONResponse(
         content=manifest,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -662,6 +662,11 @@
       }
       return obj;
     }
+    function _extractYouTubeUrl(text) {
+      if (!text) return null;
+      const m = text.match(/https?:\/\/(?:(?:www\.|m\.|music\.)?youtube\.com\/(?:watch\?[^\s]*v=|shorts\/|embed\/)|youtu\.be\/)[^\s&"')>]*/);
+      return m ? m[0] : null;
+    }
 
     function shell() {
       var _cachedPublicStream = localStorage.getItem('radioPublicStreamUrl') || '';
@@ -706,11 +711,21 @@
         passBusy: false,
         passError: '',
         passkeys: [],
+        shareUrl: '',
 
         async init() {
           // Guard: Alpine calls init() twice (auto-detect + x-init attribute).
           if (this._initRunning) return;
           this._initRunning = true;
+
+          // Parse Web Share Target query params (Android share sheet)
+          const _sp = new URLSearchParams(location.search);
+          const _shareUrl = _extractYouTubeUrl(_sp.get('url') || '')
+                         || _extractYouTubeUrl(_sp.get('text') || '');
+          if (_shareUrl) {
+            this.shareUrl = _shareUrl;
+            history.replaceState(null, '', '/');  // clean query string immediately
+          }
 
           console.log('[radio] init — streamUrl:', this.streamUrl, 'publicStreamUrl:', this.publicStreamUrl);
 
@@ -772,7 +787,12 @@
             if (res.ok) {
               this.user = await res.json();
               this.authChecked = true;
-              this._applyHash(location.hash);
+              if (this.shareUrl) {
+                this.view = 'submit';
+                history.replaceState(null, '', '/#submit');
+              } else {
+                this._applyHash(location.hash);
+              }
               this.refresh();
               setInterval(() => this.refresh(), 15000);
             } else {
@@ -1134,7 +1154,12 @@
         },
 
         _routeToApp() {
-          this._applyHash(location.hash);
+          if (this.shareUrl) {
+            this.view = 'submit';
+            history.replaceState(null, '', '/#submit');
+          } else {
+            this._applyHash(location.hash);
+          }
           this.refresh();
           setInterval(() => this.refresh(), 15000);
         },
@@ -1264,6 +1289,17 @@
 
         initSubmit() {
           // No submitter fetch needed — name comes from the logged-in user
+          // Watch for the view transitioning TO 'submit'. We can't act on shareUrl
+          // immediately here because initSubmit() runs while init() is awaiting the
+          // auth fetch — clearing shareUrl now would prevent the auth-success branch
+          // from seeing it and navigating to this view.
+          this.$watch('view', (v) => {
+            if (v !== 'submit' || !this.shareUrl) return;
+            this.tab = 'youtube';
+            this.youtubeUrl = this.shareUrl;
+            this.shareUrl = '';
+            this.$nextTick(() => this.scheduleDupCheck());
+          });
         },
 
         fileSelected(event) {


### PR DESCRIPTION
## Summary

- Adds PWA Web Share Target support so the app appears in the Android OS share sheet when sharing from YouTube (or any app)
- Sharing a YouTube URL opens the PWA to the Submit view with the URL pre-filled and duplicate check running
- Works for both signed-in users (direct to submit) and unauthenticated users (stores URL through login flow, then routes to submit)

## Approach

**Manifest (`api/routers/push.py`):** Added `share_target` with `action: "/"`, `method: "GET"`, and params mapping `title`/`text`/`url`. GET method passes params as query string — no service worker interception needed, and `action: "/"` is within the PWA scope served by nginx's `location = /` block.

**Frontend (`frontend/index.html`):**
- `_extractYouTubeUrl()` helper handles `youtube.com`, `youtu.be`, `m.youtube.com`, `music.youtube.com`, and Shorts URLs; also checks `?text=` since some apps put the URL there rather than `?url=`
- `shareUrl` state property on `shell()` holds the extracted URL across the auth flow
- Query param parsing runs synchronously in `init()` before `await fetch('/api/auth/me')`, storing the URL and immediately cleaning the query string
- Auth-success branch and `_routeToApp()` both check `shareUrl` and navigate to `/#submit` when set
- `initSubmit()` uses `$watch('view', ...)` to pre-fill the form when the view transitions to `'submit'`

**Key timing constraint:** Alpine initialises child `x-data` components (including `submitView`) while `init()` is suspended at the auth fetch, so `initSubmit()` runs before auth completes. The watch must be on `view`, not `shareUrl` — watching `shareUrl` or applying immediately would clear it before the auth-success branch ever sees it, breaking navigation to the submit view.

## Test plan

- [x] `http://localhost/?url=https://www.youtube.com/watch?v=dQw4w9WgXcQ` while signed in → redirects to `/#submit` with URL pre-filled and dup check running
- [x] `?text=Check+this+out+https://youtu.be/xxx` → URL extracted from text param
- [x] Normal navigation to `/` → routes to `/#playing` as before
- [ ] Share URL while logged out → stores URL, shows login, routes to submit after sign-in
- [x] `GET /api/manifest.json` includes `share_target` key
- [ ] Android device: install PWA → share YouTube video → app appears in share sheet and pre-fills correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)