### PR TITLE
ci: drop Barton from nightly-rebuild matrix

### DIFF
--- a/.github/workflows/nightly-rebuild.yml
+++ b/.github/workflows/nightly-rebuild.yml
@@ -15,8 +15,8 @@ jobs:
         station:
           - name: maier
             instance_id: i-04cf8f3c771ae92c8
-          - name: barton
-            instance_id: i-06a19a026aefd4c7d
+          # Barton paused 2026-04-28 — instance terminated. Re-add an entry with the new
+          # instance_id if Barton is restored.
 
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary

- Drop the `barton` matrix entry from the nightly API rebuild workflow so it stops failing every night against the now-terminated Barton instance.

## Context

Barton was paused on 2026-04-28 — EC2 instance `i-06a19a026aefd4c7d` terminated, Elastic IP released, EBS auto-deleted. Local archive of DB/media/config preserved at `~/radio-barton-archive-2026-04-28/` for restore. The S3 backup bucket `radio-barton-backup` is retained as a second copy.

The matrix entry is replaced with a comment so it's obvious where to re-add the station if Barton ever comes back.

## Test plan

- [ ] Next nightly run (3am CST) only attempts Maier and exits clean.
- [ ] `workflow_dispatch` succeeds on Maier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)