### PR TITLE
fix: delete DJ interlude files after playback

### DIFF
--- a/api/dj.py
+++ b/api/dj.py
@@ -29,6 +29,20 @@ def _dj_dir() -> str:
     return path
 
 
+def cleanup_stale_dj_files() -> None:
+    """Delete any dj/ files left over from previous runs (already played or abandoned)."""
+    keep = {get_config("dj_pending_file"), get_config("dj_playing_file")} - {""}
+    dj_dir = _dj_dir()
+    for fname in os.listdir(dj_dir):
+        fpath = os.path.join(dj_dir, fname)
+        if fpath not in keep:
+            try:
+                os.remove(fpath)
+                logger.info("DJ cleanup: removed stale file %s", fpath)
+            except OSError:
+                logger.warning("DJ cleanup: could not remove %s", fpath, exc_info=True)
+
+
 def _round_time_label(dt: datetime) -> str:
     """Return a natural time label rounded to the nearest quarter hour.
 

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,7 @@ import os
 from contextlib import asynccontextmanager
 
 from database import init_db
+from dj import cleanup_stale_dj_files
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from metrics import start_metrics_poller, stop_metrics_poller
@@ -22,6 +23,7 @@ async def lifespan(app: FastAPI):
     logger.info("Starting up %s API", _station_name)
     init_db()
     reset_stuck_jobs()
+    cleanup_stale_dj_files()
     start_worker()
     start_metrics_poller()
     yield

--- a/api/routers/internal.py
+++ b/api/routers/internal.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import UTC, datetime, timedelta
 
 from database import db, get_config, set_config
@@ -42,6 +43,14 @@ def track_started(track_id: str):
     # DJ interludes are not in the tracks table — handle them cleanly without a warning.
     if track_id == DJ_SENTINEL:
         logger.info("DJ interlude started playing")
+        playing_file = get_config("dj_playing_file")
+        if playing_file:
+            set_config("dj_playing_file", "")
+            try:
+                os.remove(playing_file)
+                logger.info("DJ: deleted played interlude file %s", playing_file)
+            except OSError:
+                logger.warning("DJ: could not delete interlude file %s", playing_file, exc_info=True)
         return {"ok": True}
 
     with db() as conn:

--- a/api/scheduler.py
+++ b/api/scheduler.py
@@ -296,6 +296,7 @@ def get_next_track() -> dict | None:
         pending_file = get_config("dj_pending_file")
         if pending_file and os.path.exists(pending_file):
             reserved_id = get_config("dj_reserved_track_id")
+            set_config("dj_playing_file", pending_file)
             set_config("dj_pending_file", "")
             set_config("dj_submitters_since_last_interlude", "0")
             set_config("last_returned_track_id", "")


### PR DESCRIPTION
## Problem

Generated DJ interlude MP3s (~1 MB each) were never deleted from `media/dj/`. After ~4 weeks of use on Maier, 21 files (~21 MB) had accumulated. Left unchecked this would grow indefinitely.

## Approach

Two-phase cleanup:

**On playback (normal path):**
- `scheduler.py`: when dispatching an interlude, write the file path to a new `dj_playing_file` config key before clearing `dj_pending_file` (so the path isn't lost between dispatch and acknowledgement)
- `internal.py`: when `track-started` fires for `DJ_SENTINEL`, read `dj_playing_file`, delete the file, and clear the key

**At startup (handles accumulation and crash/restart edge cases):**
- `dj.py`: `cleanup_stale_dj_files()` deletes all files in `media/dj/` that aren't currently referenced by `dj_pending_file` or `dj_playing_file`
- `main.py`: call it at startup alongside `reset_stuck_jobs()`

The 21 accumulated files on Maier will be cleared on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)