### PR TITLE
Add programmed playback mode

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -103,6 +103,21 @@ CREATE TABLE IF NOT EXISTS passkey_challenges (
     type TEXT NOT NULL,
     expires_at TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS programs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS program_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    program_id INTEGER NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+    track_id TEXT NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
+    position INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_program_items_program ON program_items(program_id, position);
 """
 
 CONFIG_DEFAULTS = {
@@ -121,6 +136,9 @@ CONFIG_DEFAULTS = {
     "dj_interlude_just_played": "false",
     "dj_last_script": "",
     "dj_prev_script": "",
+    "active_program_id": "",
+    "program_current_position": "0",
+    "program_pending_position": "",
     "feature_min_tempo_bpm": "0",
     "feature_max_tempo_bpm": "1",
     "feature_min_rms_energy": "0",
@@ -181,6 +199,10 @@ def init_db():
             pass  # column already exists
         try:
             conn.execute("ALTER TABLE push_subscriptions ADD COLUMN user_id TEXT REFERENCES users(id)")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        try:
+            conn.execute("ALTER TABLE tracks ADD COLUMN in_rotation INTEGER NOT NULL DEFAULT 1")
         except sqlite3.OperationalError:
             pass  # column already exists
         # Backfill youtube_video_id from source_url for tracks submitted before this column existed

--- a/api/main.py
+++ b/api/main.py
@@ -7,7 +7,7 @@ from dj import cleanup_stale_dj_files
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from metrics import start_metrics_poller, stop_metrics_poller
-from routers import admin, auth, internal, push, status, submit
+from routers import admin, auth, internal, programs, push, status, submit
 from worker import reset_stuck_jobs, start_worker, stop_worker
 
 logging.basicConfig(
@@ -49,6 +49,7 @@ app.include_router(auth.router)
 app.include_router(submit.router)
 app.include_router(internal.router)
 app.include_router(admin.router)
+app.include_router(programs.router)
 app.include_router(status.router)
 app.include_router(push.router)
 

--- a/api/routers/admin.py
+++ b/api/routers/admin.py
@@ -27,24 +27,87 @@ class ConfigUpdate(BaseModel):
     rotation_tracks_per_block: int | None = None
     dj_enabled: bool | None = None
     dj_submitters_per_interlude: int | None = None
+    active_program_id: int | None = None
+
+
+def _resolved_active_program_id(update: ConfigUpdate) -> int | None:
+    if update.active_program_id is not None:
+        return update.active_program_id
+    raw = get_config("active_program_id")
+    return int(raw) if raw else None
+
+
+def _clear_dj_pending_state():
+    """Clear any in-flight DJ generation state. Used when entering programmed mode."""
+    pending_file = get_config("dj_pending_file")
+    if pending_file and os.path.exists(pending_file):
+        try:
+            os.unlink(pending_file)
+        except OSError:
+            pass
+    set_config("dj_pending_file", "")
+    set_config("dj_reserved_track_id", "")
+    set_config("dj_interlude_just_played", "false")
+    set_config("dj_generation_needed", "false")
 
 
 @router.get("/admin/config")
 def get_admin_config(auth=Depends(require_admin)):
+    active_program_id_raw = get_config("active_program_id")
+    active_program_id = int(active_program_id_raw) if active_program_id_raw else None
+    active_program_name = None
+    active_program_item_count = 0
+    if active_program_id:
+        with db() as conn:
+            row = conn.execute("SELECT name FROM programs WHERE id=?", (active_program_id,)).fetchone()
+            if row:
+                active_program_name = row["name"]
+                active_program_item_count = conn.execute(
+                    "SELECT COUNT(*) FROM program_items WHERE program_id=?", (active_program_id,)
+                ).fetchone()[0]
+            else:
+                active_program_id = None  # stale id; surface as cleared
     return {
         "programming_mode": get_config("programming_mode"),
         "rotation_tracks_per_block": int(get_config("rotation_tracks_per_block")),
         "rotation_current_submitter_idx": int(get_config("rotation_current_submitter_idx")),
         "dj_enabled": get_config("dj_enabled") == "true",
         "dj_submitters_per_interlude": int(get_config("dj_submitters_per_interlude") or "2"),
+        "active_program_id": active_program_id,
+        "active_program_name": active_program_name,
+        "active_program_item_count": active_program_item_count,
+        "program_current_position": int(get_config("program_current_position") or "0"),
     }
 
 
 @router.post("/admin/config")
 def update_admin_config(update: ConfigUpdate, auth=Depends(require_admin)):
     if update.programming_mode is not None:
-        if update.programming_mode not in ("rotation", "mood"):
-            raise HTTPException(400, "programming_mode must be 'rotation' or 'mood'")
+        if update.programming_mode not in ("rotation", "mood", "programmed"):
+            raise HTTPException(400, "programming_mode must be 'rotation', 'mood', or 'programmed'")
+
+        if update.programming_mode == "programmed":
+            pid = _resolved_active_program_id(update)
+            if not pid:
+                raise HTTPException(400, "active_program_id is required to switch to programmed mode")
+            with db() as conn:
+                program = conn.execute("SELECT id FROM programs WHERE id=?", (pid,)).fetchone()
+                if not program:
+                    raise HTTPException(400, f"Program {pid} not found")
+                item_count = conn.execute("SELECT COUNT(*) FROM program_items WHERE program_id=?", (pid,)).fetchone()[0]
+            if item_count == 0:
+                raise HTTPException(400, "Cannot activate an empty program")
+            set_config("active_program_id", str(pid))
+            set_config("program_current_position", "0")
+            set_config("program_pending_position", "")
+            _clear_dj_pending_state()
+        else:
+            # Switching away from programmed — clear program state.
+            if get_config("programming_mode") == "programmed":
+                set_config("active_program_id", "")
+                set_config("program_current_position", "0")
+                set_config("program_pending_position", "")
+
         set_config("programming_mode", update.programming_mode)
         logger.info(f"Programming mode set to: {update.programming_mode}")
 
@@ -75,6 +138,14 @@ def _liquidsoap_skip():
     # = flushed prefetch, last_played = the skipped track), triggering an early
     # submitter advance.
     set_config("last_returned_track_id", "")
+    # In programmed mode, the prefetched-but-not-yet-started item is about to be
+    # flushed by Liquidsoap. Roll the position back so the next pick returns it
+    # again — otherwise the program silently skips an item it never played.
+    if get_config("programming_mode") == "programmed":
+        pending = get_config("program_pending_position")
+        if pending:
+            set_config("program_current_position", pending)
+            set_config("program_pending_position", "")
     with socket.create_connection(("liquidsoap", 1234), timeout=5) as sock:
         sock.sendall(b"dynamic.flush_and_skip\nquit\n")
         sock.recv(1024)  # drain response
@@ -109,6 +180,26 @@ async def upload_youtube_cookies(file: UploadFile = File(...), auth=Depends(requ
         f.write(content)
     set_config("youtube_cookies_uploaded_at", datetime.now(UTC).isoformat())
     logger.info("YouTube cookies updated")
+    return {"ok": True}
+
+
+class TrackUpdate(BaseModel):
+    in_rotation: bool | None = None
+
+
+@router.patch("/admin/track/{track_id}")
+def update_track(track_id: str, update: TrackUpdate, auth=Depends(require_admin)):
+    """Update mutable per-track admin fields."""
+    with db() as conn:
+        row = conn.execute("SELECT id FROM tracks WHERE id=?", (track_id,)).fetchone()
+        if not row:
+            raise HTTPException(404, "Track not found")
+        if update.in_rotation is not None:
+            conn.execute(
+                "UPDATE tracks SET in_rotation=? WHERE id=?",
+                (1 if update.in_rotation else 0, track_id),
+            )
+            logger.info(f"Track {track_id} in_rotation set to: {update.in_rotation}")
     return {"ok": True}
 
 

--- a/api/routers/internal.py
+++ b/api/routers/internal.py
@@ -68,6 +68,29 @@ def track_started(track_id: str):
 
     logger.info(f"track-started logged: {track_id}")
 
+    # In programmed mode, clear the pending-prefetch marker only if the just-started
+    # track is actually the item at the pending position. Without this match check,
+    # track-started for the *current* track can race with the prefetch (which sets
+    # pending) and clobber it — so a later skip wouldn't rewind to the flushed item.
+    if get_config("programming_mode") == "programmed":
+        pending_str = get_config("program_pending_position")
+        active_id_str = get_config("active_program_id")
+        if pending_str and active_id_str:
+            try:
+                pending_idx = int(pending_str)
+                active_id = int(active_id_str)
+            except ValueError:
+                pending_idx = None
+                active_id = None
+            if pending_idx is not None and active_id is not None:
+                with db() as conn:
+                    row = conn.execute(
+                        "SELECT track_id FROM program_items WHERE program_id=? AND position=?",
+                        (active_id, pending_idx),
+                    ).fetchone()
+                if row and row["track_id"] == track_id:
+                    set_config("program_pending_position", "")
+
     # DJ interlude generation trigger. dj_generation_needed is set by _advance() when
     # dj_submitters_since_last_interlude reaches threshold-1, meaning we've entered the
     # last submitter block before an interlude is due. We wait until the *penultimate*

--- a/api/routers/programs.py
+++ b/api/routers/programs.py
@@ -1,0 +1,431 @@
+import json
+import logging
+import re
+from datetime import UTC, datetime
+
+from database import db, get_config, set_config
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from routers.admin import require_admin
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+MANIFEST_VERSION = 1
+
+
+class ProgramCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+
+
+class ProgramRename(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+
+
+class ProgramItemCreate(BaseModel):
+    track_id: str
+    position: int | None = None  # None = append
+
+
+class ProgramItemsReorder(BaseModel):
+    item_ids: list[int]
+
+
+class ProgramManifestItem(BaseModel):
+    track_id: str | None = None
+    title: str
+    artist: str
+    submitter: str
+
+
+class ProgramManifest(BaseModel):
+    version: int
+    name: str = Field(min_length=1, max_length=200)
+    items: list[ProgramManifestItem]
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _active_program_id() -> int | None:
+    raw = get_config("active_program_id")
+    return int(raw) if raw else None
+
+
+def _program_summary(conn, row) -> dict:
+    counts = conn.execute(
+        """
+        SELECT COUNT(*) AS item_count, COALESCE(SUM(t.duration_s), 0) AS total_duration_s
+        FROM program_items pi
+        LEFT JOIN tracks t ON pi.track_id = t.id
+        WHERE pi.program_id = ?
+        """,
+        (row["id"],),
+    ).fetchone()
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "item_count": counts["item_count"],
+        "total_duration_s": counts["total_duration_s"],
+    }
+
+
+def _program_detail(conn, program_id: int) -> dict | None:
+    row = conn.execute("SELECT id, name, created_at, updated_at FROM programs WHERE id=?", (program_id,)).fetchone()
+    if not row:
+        return None
+    items = conn.execute(
+        """
+        SELECT pi.id AS item_id, pi.position,
+               t.id AS track_id, t.title, t.artist, t.submitter, t.duration_s,
+               t.status, t.in_rotation
+        FROM program_items pi
+        JOIN tracks t ON pi.track_id = t.id
+        WHERE pi.program_id = ?
+        ORDER BY pi.position ASC
+        """,
+        (program_id,),
+    ).fetchall()
+    item_dicts = [
+        {
+            "item_id": item["item_id"],
+            "position": item["position"],
+            "track_id": item["track_id"],
+            "title": item["title"],
+            "artist": item["artist"],
+            "submitter": item["submitter"],
+            "duration_s": item["duration_s"],
+            "status": item["status"],
+            "in_rotation": bool(item["in_rotation"]),
+        }
+        for item in items
+    ]
+    total_duration_s = sum(i["duration_s"] or 0 for i in item_dicts)
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "is_active": _active_program_id() == row["id"],
+        "items": item_dicts,
+        "total_duration_s": total_duration_s,
+    }
+
+
+def _touch_program(conn, program_id: int):
+    conn.execute("UPDATE programs SET updated_at=? WHERE id=?", (_now_iso(), program_id))
+
+
+def _renumber_positions(conn, program_id: int):
+    """Rewrite positions to a contiguous 0..N-1 sequence in current order."""
+    items = conn.execute(
+        "SELECT id FROM program_items WHERE program_id=? ORDER BY position ASC, id ASC",
+        (program_id,),
+    ).fetchall()
+    for new_pos, row in enumerate(items):
+        conn.execute("UPDATE program_items SET position=? WHERE id=?", (new_pos, row["id"]))
+
+
+def _clamp_position_for_active(program_id: int):
+    """If `program_id` is the active program, clamp position to within current items
+    and clear the pending-prefetch marker — its position reference may no longer
+    point at the item Liquidsoap has actually buffered after a mutation."""
+    if _active_program_id() != program_id:
+        return
+    with db() as conn:
+        n = conn.execute("SELECT COUNT(*) AS n FROM program_items WHERE program_id=?", (program_id,)).fetchone()["n"]
+    pos = int(get_config("program_current_position") or "0")
+    if pos > n:
+        set_config("program_current_position", str(n))
+    set_config("program_pending_position", "")
+
+
+@router.get("/admin/programs")
+def list_programs(auth=Depends(require_admin)):
+    with db() as conn:
+        rows = conn.execute(
+            "SELECT id, name, created_at, updated_at FROM programs ORDER BY name COLLATE NOCASE"
+        ).fetchall()
+        active = _active_program_id()
+        programs = []
+        for r in rows:
+            summary = _program_summary(conn, r)
+            summary["is_active"] = r["id"] == active
+            programs.append(summary)
+    return {"programs": programs}
+
+
+@router.post("/admin/programs")
+def create_program(payload: ProgramCreate, auth=Depends(require_admin)):
+    now = _now_iso()
+    with db() as conn:
+        cursor = conn.execute(
+            "INSERT INTO programs (name, created_at, updated_at) VALUES (?, ?, ?)",
+            (payload.name, now, now),
+        )
+        program_id = cursor.lastrowid
+        detail = _program_detail(conn, program_id)
+    logger.info(f"Created program {program_id}: {payload.name!r}")
+    return detail
+
+
+@router.get("/admin/programs/{program_id}")
+def get_program(program_id: int, auth=Depends(require_admin)):
+    with db() as conn:
+        detail = _program_detail(conn, program_id)
+    if not detail:
+        raise HTTPException(404, "Program not found")
+    return detail
+
+
+@router.patch("/admin/programs/{program_id}")
+def rename_program(program_id: int, payload: ProgramRename, auth=Depends(require_admin)):
+    with db() as conn:
+        row = conn.execute("SELECT id FROM programs WHERE id=?", (program_id,)).fetchone()
+        if not row:
+            raise HTTPException(404, "Program not found")
+        conn.execute(
+            "UPDATE programs SET name=?, updated_at=? WHERE id=?",
+            (payload.name, _now_iso(), program_id),
+        )
+        return _program_detail(conn, program_id)
+
+
+@router.delete("/admin/programs/{program_id}")
+def delete_program(program_id: int, auth=Depends(require_admin)):
+    with db() as conn:
+        row = conn.execute("SELECT id FROM programs WHERE id=?", (program_id,)).fetchone()
+        if not row:
+            raise HTTPException(404, "Program not found")
+        conn.execute("DELETE FROM programs WHERE id=?", (program_id,))
+
+    if _active_program_id() == program_id:
+        set_config("active_program_id", "")
+        set_config("program_current_position", "0")
+        set_config("program_pending_position", "")
+        if get_config("programming_mode") == "programmed":
+            set_config("programming_mode", "rotation")
+            logger.info(f"Active program {program_id} deleted while in programmed mode; reverting to rotation")
+    logger.info(f"Deleted program {program_id}")
+    return {"ok": True}
+
+
+@router.post("/admin/programs/{program_id}/items")
+def add_program_item(program_id: int, payload: ProgramItemCreate, auth=Depends(require_admin)):
+    with db() as conn:
+        program = conn.execute("SELECT id FROM programs WHERE id=?", (program_id,)).fetchone()
+        if not program:
+            raise HTTPException(404, "Program not found")
+        track = conn.execute("SELECT id FROM tracks WHERE id=?", (payload.track_id,)).fetchone()
+        if not track:
+            raise HTTPException(404, "Track not found")
+
+        if payload.position is None:
+            next_pos = conn.execute(
+                "SELECT COALESCE(MAX(position) + 1, 0) AS p FROM program_items WHERE program_id=?",
+                (program_id,),
+            ).fetchone()["p"]
+            position = next_pos
+        else:
+            position = max(0, payload.position)
+            conn.execute(
+                "UPDATE program_items SET position = position + 1 WHERE program_id=? AND position >= ?",
+                (program_id, position),
+            )
+
+        conn.execute(
+            "INSERT INTO program_items (program_id, track_id, position) VALUES (?, ?, ?)",
+            (program_id, payload.track_id, position),
+        )
+        _renumber_positions(conn, program_id)
+        _touch_program(conn, program_id)
+        detail = _program_detail(conn, program_id)
+
+    _clamp_position_for_active(program_id)
+    return detail
+
+
+@router.delete("/admin/programs/{program_id}/items/{item_id}")
+def remove_program_item(program_id: int, item_id: int, auth=Depends(require_admin)):
+    with db() as conn:
+        row = conn.execute(
+            "SELECT id FROM program_items WHERE id=? AND program_id=?",
+            (item_id, program_id),
+        ).fetchone()
+        if not row:
+            raise HTTPException(404, "Item not found")
+        conn.execute("DELETE FROM program_items WHERE id=?", (item_id,))
+        _renumber_positions(conn, program_id)
+        _touch_program(conn, program_id)
+        detail = _program_detail(conn, program_id)
+
+    _clamp_position_for_active(program_id)
+    return detail
+
+
+@router.patch("/admin/programs/{program_id}/items")
+def reorder_program_items(program_id: int, payload: ProgramItemsReorder, auth=Depends(require_admin)):
+    with db() as conn:
+        program = conn.execute("SELECT id FROM programs WHERE id=?", (program_id,)).fetchone()
+        if not program:
+            raise HTTPException(404, "Program not found")
+
+        existing_rows = conn.execute("SELECT id FROM program_items WHERE program_id=?", (program_id,)).fetchall()
+        existing_ids = {r["id"] for r in existing_rows}
+        if set(payload.item_ids) != existing_ids:
+            raise HTTPException(400, "item_ids must contain exactly the current items of this program")
+        for new_pos, item_id in enumerate(payload.item_ids):
+            conn.execute(
+                "UPDATE program_items SET position=? WHERE id=? AND program_id=?",
+                (new_pos, item_id, program_id),
+            )
+        _touch_program(conn, program_id)
+        result = _program_detail(conn, program_id)
+
+    _clamp_position_for_active(program_id)
+    return result
+
+
+@router.post("/admin/programs/{program_id}/activate")
+def activate_program(program_id: int, auth=Depends(require_admin)):
+    with db() as conn:
+        row = conn.execute("SELECT id FROM programs WHERE id=?", (program_id,)).fetchone()
+        if not row:
+            raise HTTPException(404, "Program not found")
+        item_count = conn.execute("SELECT COUNT(*) FROM program_items WHERE program_id=?", (program_id,)).fetchone()[0]
+    if item_count == 0:
+        raise HTTPException(400, "Cannot activate an empty program")
+    set_config("active_program_id", str(program_id))
+    set_config("program_current_position", "0")
+    set_config("program_pending_position", "")
+    logger.info(f"Activated program {program_id}")
+    return {"ok": True, "active_program_id": program_id}
+
+
+@router.get("/admin/programs/{program_id}/export")
+def export_program(program_id: int, auth=Depends(require_admin)):
+    with db() as conn:
+        row = conn.execute("SELECT id, name FROM programs WHERE id=?", (program_id,)).fetchone()
+        if not row:
+            raise HTTPException(404, "Program not found")
+        items = conn.execute(
+            """
+            SELECT t.id AS track_id, t.title, t.artist, t.submitter
+            FROM program_items pi
+            JOIN tracks t ON pi.track_id = t.id
+            WHERE pi.program_id = ?
+            ORDER BY pi.position ASC
+            """,
+            (program_id,),
+        ).fetchall()
+
+    manifest = {
+        "version": MANIFEST_VERSION,
+        "name": row["name"],
+        "items": [
+            {
+                "track_id": item["track_id"],
+                "title": item["title"],
+                "artist": item["artist"],
+                "submitter": item["submitter"],
+            }
+            for item in items
+        ],
+    }
+    body = json.dumps(manifest, indent=2)
+    safe_name = re.sub(r"[^A-Za-z0-9_-]+", "_", row["name"]).strip("_") or "program"
+    filename = f"{safe_name}.json"
+    return Response(
+        content=body,
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _match_track(conn, item: ProgramManifestItem) -> str | None:
+    """Resolve a manifest item to a track_id in the local library, or None."""
+    if item.track_id:
+        row = conn.execute("SELECT id FROM tracks WHERE id=?", (item.track_id,)).fetchone()
+        if row:
+            return row["id"]
+    row = conn.execute(
+        """
+        SELECT id FROM tracks
+        WHERE LOWER(title)=LOWER(?) AND LOWER(artist)=LOWER(?) AND LOWER(submitter)=LOWER(?)
+        ORDER BY submitted_at ASC LIMIT 1
+        """,
+        (item.title, item.artist, item.submitter),
+    ).fetchone()
+    if row:
+        return row["id"]
+    row = conn.execute(
+        """
+        SELECT id FROM tracks
+        WHERE LOWER(title)=LOWER(?) AND LOWER(artist)=LOWER(?)
+        ORDER BY submitted_at ASC LIMIT 1
+        """,
+        (item.title, item.artist),
+    ).fetchone()
+    if row:
+        return row["id"]
+    return None
+
+
+@router.post("/admin/programs/import")
+async def import_program(file: UploadFile = File(...), auth=Depends(require_admin)):
+    raw = await file.read()
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        raise HTTPException(400, f"Invalid manifest JSON: {e}") from None
+    try:
+        manifest = ProgramManifest.model_validate(data)
+    except ValueError as e:
+        raise HTTPException(400, f"Manifest schema error: {e}") from None
+    if manifest.version != MANIFEST_VERSION:
+        raise HTTPException(400, f"Unsupported manifest version {manifest.version} (expected {MANIFEST_VERSION})")
+
+    now = _now_iso()
+    unmatched: list[dict] = []
+    matched_track_ids: list[str] = []
+    with db() as conn:
+        for original_position, item in enumerate(manifest.items):
+            tid = _match_track(conn, item)
+            if tid is None:
+                unmatched.append(
+                    {
+                        "position": original_position,
+                        "title": item.title,
+                        "artist": item.artist,
+                        "submitter": item.submitter,
+                    }
+                )
+            else:
+                matched_track_ids.append(tid)
+
+        cursor = conn.execute(
+            "INSERT INTO programs (name, created_at, updated_at) VALUES (?, ?, ?)",
+            (manifest.name, now, now),
+        )
+        program_id = cursor.lastrowid
+        for new_pos, tid in enumerate(matched_track_ids):
+            conn.execute(
+                "INSERT INTO program_items (program_id, track_id, position) VALUES (?, ?, ?)",
+                (program_id, tid, new_pos),
+            )
+
+    logger.info(
+        f"Imported program {program_id} ({manifest.name!r}): "
+        f"{len(matched_track_ids)} matched, {len(unmatched)} unmatched"
+    )
+    return {
+        "program_id": program_id,
+        "name": manifest.name,
+        "imported": len(matched_track_ids),
+        "unmatched": unmatched,
+    }

--- a/api/routers/status.py
+++ b/api/routers/status.py
@@ -25,6 +25,7 @@ def _track_row_to_dict(row) -> dict:
         "submitted_at": row["submitted_at"],
         "ready_at": row["ready_at"],
         "comment": row["comment"],
+        "in_rotation": bool(row["in_rotation"]),
     }
 
 

--- a/api/scheduler.py
+++ b/api/scheduler.py
@@ -17,7 +17,8 @@ COOLDOWN_WINDOW_S = 3600  # don't replay a track within 60 min
 def _total_ready_runtime_s() -> float:
     with db() as conn:
         return conn.execute(
-            "SELECT COALESCE(SUM(duration_s), 0) FROM tracks WHERE status='ready' AND duration_s IS NOT NULL"
+            "SELECT COALESCE(SUM(duration_s), 0) FROM tracks "
+            "WHERE status='ready' AND in_rotation=1 AND duration_s IS NOT NULL"
         ).fetchone()[0]
 
 
@@ -35,7 +36,7 @@ def _pick_global_fallback() -> dict | None:
         row = conn.execute(
             """
             SELECT t.id, t.title, t.artist, t.submitter, t.file_path FROM tracks t
-            WHERE t.status='ready' AND t.id != ? AND t.id != ?
+            WHERE t.status='ready' AND t.in_rotation=1 AND t.id != ? AND t.id != ?
             ORDER BY COALESCE(
                 (SELECT MAX(pl.played_at) FROM play_log pl WHERE pl.track_id=t.id), ''
             ) ASC, t.submitted_at ASC
@@ -47,7 +48,7 @@ def _pick_global_fallback() -> dict | None:
         if not row:  # truly last resort — allow any ready track
             row = conn.execute("""
                 SELECT t.id, t.title, t.artist, t.submitter, t.file_path FROM tracks t
-                WHERE t.status='ready'
+                WHERE t.status='ready' AND t.in_rotation=1
                 ORDER BY COALESCE(
                     (SELECT MAX(pl.played_at) FROM play_log pl WHERE pl.track_id=t.id), ''
                 ) ASC, t.submitted_at ASC
@@ -74,7 +75,9 @@ def _advance_for_dj():
     (caller resets dj_submitters_since_last_interlude directly).
     """
     with db() as conn:
-        rows = conn.execute("SELECT DISTINCT submitter FROM tracks WHERE status='ready' ORDER BY submitter").fetchall()
+        rows = conn.execute(
+            "SELECT DISTINCT submitter FROM tracks WHERE status='ready' AND in_rotation=1 ORDER BY submitter"
+        ).fetchall()
         submitters = [r["submitter"] for r in rows]
 
     if not submitters:
@@ -135,7 +138,7 @@ def is_penultimate_submitter_track(submitter: str, track_id: str) -> bool:
             remaining = conn.execute(
                 """
                 SELECT COUNT(*) FROM tracks
-                WHERE submitter = ? AND status = 'ready'
+                WHERE submitter = ? AND status = 'ready' AND in_rotation = 1
                   AND id != ?
                   AND id != ?
                   AND id NOT IN (SELECT track_id FROM play_log WHERE played_at > ?)
@@ -146,7 +149,7 @@ def is_penultimate_submitter_track(submitter: str, track_id: str) -> bool:
             remaining = conn.execute(
                 """
                 SELECT COUNT(*) FROM tracks
-                WHERE submitter = ? AND status = 'ready'
+                WHERE submitter = ? AND status = 'ready' AND in_rotation = 1
                   AND id != ?
                   AND id != ?
                 """,
@@ -177,7 +180,9 @@ def peek_next_submitter_track() -> dict | None:
     is found, rather than returning None and silently suppressing DJ generation.
     """
     with db() as conn:
-        rows = conn.execute("SELECT DISTINCT submitter FROM tracks WHERE status='ready' ORDER BY submitter").fetchall()
+        rows = conn.execute(
+            "SELECT DISTINCT submitter FROM tracks WHERE status='ready' AND in_rotation=1 ORDER BY submitter"
+        ).fetchall()
         submitters = [r["submitter"] for r in rows]
 
     if not submitters:
@@ -203,7 +208,7 @@ def peek_next_submitter_track() -> dict | None:
                            COUNT(pl.id) as play_count
                     FROM tracks t
                     LEFT JOIN play_log pl ON pl.track_id = t.id
-                    WHERE t.submitter=? AND t.status='ready'
+                    WHERE t.submitter=? AND t.status='ready' AND t.in_rotation=1
                       AND t.id != ?
                       AND t.id != ?
                       AND t.id NOT IN (SELECT track_id FROM play_log WHERE played_at > ?)
@@ -218,7 +223,7 @@ def peek_next_submitter_track() -> dict | None:
                            COUNT(pl.id) as play_count
                     FROM tracks t
                     LEFT JOIN play_log pl ON pl.track_id = t.id
-                    WHERE t.submitter=? AND t.status='ready'
+                    WHERE t.submitter=? AND t.status='ready' AND t.in_rotation=1
                       AND t.id != ?
                       AND t.id != ?
                     GROUP BY t.id
@@ -254,10 +259,17 @@ def get_next_track() -> dict | None:
     Main scheduling entry point. Returns a dict with id/title/artist/file_path
     for the next track to play, or None if nothing is ready.
 
-    Before normal scheduling, checks for a pending DJ interlude (dj_pending_file).
-    When an interlude is returned, the rotation is immediately advanced to the next
-    submitter so normal scheduling picks up correctly after the interlude plays.
+    Programmed mode short-circuits before the DJ block — programmed playlists
+    are fully static, so DJ interludes are suppressed entirely.
+
+    Otherwise, checks for a pending DJ interlude (dj_pending_file). When an interlude
+    is returned, the rotation is immediately advanced to the next submitter so normal
+    scheduling picks up correctly after the interlude plays.
     """
+    mode = get_config("programming_mode")
+    if mode == "programmed":
+        return _pick_programmed_track()
+
     if get_config("dj_enabled") == "true":
         # Step 1: interlude just played — return the reserved post-interlude track.
         # This is the only code path that consumes dj_reserved_track_id, so a skip
@@ -315,7 +327,6 @@ def get_next_track() -> dict | None:
                 "file_path": pending_file,
             }
 
-    mode = get_config("programming_mode")
     logger.info(f"Scheduling mode: {mode}")
 
     if mode == "mood":
@@ -324,10 +335,69 @@ def get_next_track() -> dict | None:
         return _pick_rotation_track()
 
 
+def _pick_programmed_track() -> dict | None:
+    """Play through the active program in order. Reverts to rotation at end-of-program."""
+    active_id_str = get_config("active_program_id")
+    if not active_id_str:
+        logger.warning("Programmed mode active but no active_program_id; reverting to rotation")
+        set_config("programming_mode", "rotation")
+        return _pick_rotation_track()
+
+    try:
+        active_id = int(active_id_str)
+    except ValueError:
+        logger.warning(f"Invalid active_program_id={active_id_str!r}; reverting to rotation")
+        set_config("programming_mode", "rotation")
+        set_config("active_program_id", "")
+        return _pick_rotation_track()
+
+    position = int(get_config("program_current_position") or "0")
+
+    with db() as conn:
+        items = conn.execute(
+            """
+            SELECT pi.position, t.id, t.title, t.artist, t.submitter, t.file_path, t.status
+            FROM program_items pi
+            JOIN tracks t ON pi.track_id = t.id
+            WHERE pi.program_id = ?
+            ORDER BY pi.position ASC
+            """,
+            (active_id,),
+        ).fetchall()
+
+    for idx in range(position, len(items)):
+        item = items[idx]
+        if item["status"] != "ready":
+            logger.info(
+                f"Programmed: skipping non-ready item at position {idx} (track {item['id']} status={item['status']})"
+            )
+            continue
+        set_config("program_current_position", str(idx + 1))
+        set_config("program_pending_position", str(idx))
+        set_config("last_returned_track_id", item["id"])
+        logger.info(f"Programmed: position {idx + 1}/{len(items)} — '{item['title']}' by {item['artist']}")
+        return {
+            "id": item["id"],
+            "title": item["title"],
+            "artist": item["artist"],
+            "submitter": item["submitter"],
+            "file_path": item["file_path"],
+        }
+
+    logger.info("Programmed: program complete; reverting to rotation mode")
+    set_config("programming_mode", "rotation")
+    set_config("active_program_id", "")
+    set_config("program_current_position", "0")
+    set_config("program_pending_position", "")
+    return _pick_rotation_track()
+
+
 def _pick_rotation_track(depth: int = 0) -> dict | None:
     """Round-robin through submitters, N tracks per block."""
     with db() as conn:
-        rows = conn.execute("SELECT DISTINCT submitter FROM tracks WHERE status='ready' ORDER BY submitter").fetchall()
+        rows = conn.execute(
+            "SELECT DISTINCT submitter FROM tracks WHERE status='ready' AND in_rotation=1 ORDER BY submitter"
+        ).fetchall()
         submitters = [r["submitter"] for r in rows]
 
     if not submitters:
@@ -400,7 +470,7 @@ def _pick_rotation_track(depth: int = 0) -> dict | None:
                        COUNT(pl.id) as play_count
                 FROM tracks t
                 LEFT JOIN play_log pl ON pl.track_id = t.id
-                WHERE t.submitter=? AND t.status='ready'
+                WHERE t.submitter=? AND t.status='ready' AND t.in_rotation=1
                   AND t.id != ?
                   AND t.id != ?
                   AND t.id NOT IN (SELECT track_id FROM play_log WHERE played_at > ?)
@@ -415,7 +485,7 @@ def _pick_rotation_track(depth: int = 0) -> dict | None:
                        COUNT(pl.id) as play_count
                 FROM tracks t
                 LEFT JOIN play_log pl ON pl.track_id = t.id
-                WHERE t.submitter=? AND t.status='ready'
+                WHERE t.submitter=? AND t.status='ready' AND t.in_rotation=1
                   AND t.id != ?
                   AND t.id != ?
                 GROUP BY t.id
@@ -498,7 +568,7 @@ def _pick_mood_track() -> dict | None:
     # Scales with library size so small libraries always have at least one candidate.
     with db() as conn:
         library_size = conn.execute(
-            "SELECT COUNT(*) FROM tracks WHERE status='ready' AND tempo_bpm IS NOT NULL"
+            "SELECT COUNT(*) FROM tracks WHERE status='ready' AND in_rotation=1 AND tempo_bpm IS NOT NULL"
         ).fetchone()[0]
 
     exclusion_count = min(max(library_size - 1, 0), 3)
@@ -510,7 +580,7 @@ def _pick_mood_track() -> dict | None:
             SELECT t.id, t.title, t.artist, t.submitter, t.file_path, t.tempo_bpm, t.rms_energy,
                    t.spectral_centroid, t.zero_crossing_rate
             FROM tracks t
-            WHERE t.status='ready' AND t.tempo_bpm IS NOT NULL
+            WHERE t.status='ready' AND t.in_rotation=1 AND t.tempo_bpm IS NOT NULL
               AND t.id NOT IN (
                   SELECT track_id FROM play_log
                   GROUP BY track_id

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -460,15 +460,19 @@
 
         <div class="card">
           <h2>Programming Mode</h2>
-          <div class="mode-toggle" style="margin-bottom:1rem">
+          <div class="mode-toggle" style="margin-bottom:1rem; display:flex; gap:0.4rem; flex-wrap:wrap">
             <button class="btn" :class="{ secondary: config.programming_mode !== 'rotation' }"
                     @click="setMode('rotation')">Rotation</button>
             <button class="btn" :class="{ secondary: config.programming_mode !== 'mood' }"
                     @click="setMode('mood')">Mood Match</button>
+            <button class="btn" :class="{ secondary: config.programming_mode !== 'programmed' }"
+                    @click="setProgrammedMode()"
+                    :disabled="!activeProgramId">Programmed</button>
           </div>
           <p style="color:var(--muted); font-size:0.875rem">
             <strong>Rotation:</strong> Round-robin through each submitter, playing N songs per block.<br>
-            <strong>Mood:</strong> Automatically picks the next song based on audio energy/feel.
+            <strong>Mood:</strong> Automatically picks the next song based on audio energy/feel.<br>
+            <strong>Programmed:</strong> Plays the active program in order, then auto-reverts to Rotation. The AI DJ is suppressed.
           </p>
 
           <div class="form-group" style="margin-top:1.2rem" x-show="config.programming_mode === 'rotation'">
@@ -476,6 +480,151 @@
             <input type="text" style="width:80px"
                    :value="config.rotation_tracks_per_block"
                    @change="setBlockSize($event.target.value)" />
+          </div>
+
+          <div x-show="config.programming_mode === 'programmed' && config.active_program_name"
+               style="margin-top:1rem; padding:0.6rem 0.8rem; background:var(--surface-2); border-radius:6px; font-size:0.875rem">
+            Now playing program: <strong x-text="config.active_program_name"></strong>
+            <span x-text="' — position ' + (config.program_current_position || 0) + ' / ' + (config.active_program_item_count || 0)"
+                  style="color:var(--muted)"></span>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Programs</h2>
+          <p style="color:var(--muted); font-size:0.875rem; margin-bottom:1rem">
+            Save a static playlist for an occasion. The "active" program is what plays
+            when Programmed mode is selected. Imported programs reference tracks by metadata —
+            tracks must already exist in this station's library.
+          </p>
+
+          <div class="form-group">
+            <label>Active program</label>
+            <select x-model="activeProgramId" @change="setActiveProgram(activeProgramId)" style="width:100%">
+              <option value="">(none)</option>
+              <template x-for="p in programs" :key="p.id">
+                <option :value="p.id" x-text="p.name + ' (' + p.item_count + ' items, ' + formatDuration(p.total_duration_s) + ')'"></option>
+              </template>
+            </select>
+          </div>
+
+          <div style="display:flex; gap:0.5rem; align-items:flex-end; margin-bottom:1rem; flex-wrap:wrap">
+            <div class="form-group" style="flex:1; min-width:180px; margin:0">
+              <label>New program name</label>
+              <input type="text" x-model="newProgramName" placeholder="e.g. Birthday Party"
+                     @keydown.enter="createProgram()" />
+            </div>
+            <button class="btn" @click="createProgram()" :disabled="!newProgramName.trim()">Create</button>
+            <button class="btn secondary" @click="$refs.importInput.click()">Import…</button>
+            <input type="file" x-ref="importInput" accept=".json" style="display:none"
+                   @change="importProgram($event)" />
+          </div>
+
+          <div x-show="programs.length === 0" class="empty-state" style="padding:0.5rem 0">
+            No programs yet. Create one above or import a manifest.
+          </div>
+
+          <template x-for="p in programs" :key="p.id">
+            <div>
+              <div class="track-item">
+                <div class="track-meta">
+                  <div class="track-title" x-text="p.name"></div>
+                  <div class="track-sub">
+                    <span x-text="p.item_count + ' items · ' + formatDuration(p.total_duration_s)"></span>
+                    <span x-show="p.is_active" style="color:var(--success); font-weight:600"> · ACTIVE</span>
+                  </div>
+                </div>
+                <div style="display:flex; gap:0.4rem; flex-shrink:0">
+                  <button class="btn" style="padding:0.35rem 0.75rem; font-size:0.8rem"
+                          @click="toggleEditProgram(p.id)"
+                          x-text="editingProgramId === p.id ? 'Close' : 'Edit'"></button>
+                  <a class="btn secondary" style="padding:0.35rem 0.75rem; font-size:0.8rem"
+                     :href="'/api/admin/programs/' + p.id + '/export'"
+                     @click="exportProgram($event, p.id)"
+                     download>Export</a>
+                  <button class="btn danger" style="padding:0.35rem 0.75rem; font-size:0.8rem"
+                          @click="deleteProgram(p.id)">✕</button>
+                </div>
+              </div>
+
+              <div x-show="editingProgramId === p.id && editingProgram"
+                   style="margin:0.5rem 0 1rem 0; padding:1rem; background:var(--surface-2); border-radius:8px">
+                <div class="form-group">
+                  <label>Rename</label>
+                  <div style="display:flex; gap:0.4rem">
+                    <input type="text" x-model="editingProgramName" style="flex:1" />
+                    <button class="btn" @click="renameProgram()" :disabled="!editingProgramName.trim() || editingProgramName === editingProgram.name">Save</button>
+                  </div>
+                </div>
+
+                <h3 style="font-size:1rem; margin:1rem 0 0.5rem 0">Items (<span x-text="editingProgram.items.length"></span>)</h3>
+                <div x-show="editingProgram.items.length === 0" class="empty-state" style="padding:0.5rem 0">
+                  No items yet — add tracks below.
+                </div>
+                <template x-for="(item, idx) in editingProgram.items" :key="item.item_id">
+                  <div class="track-item" style="background:var(--surface)">
+                    <div class="track-meta">
+                      <div class="track-title">
+                        <span x-text="(idx + 1) + '. ' + item.title"></span>
+                        <span x-show="!item.in_rotation" class="badge"
+                              style="background:var(--surface-2); color:var(--muted); margin-left:0.4rem; font-size:0.7rem">
+                          off-rotation
+                        </span>
+                        <span x-show="item.status !== 'ready'" class="badge"
+                              :class="item.status" style="margin-left:0.4rem; font-size:0.7rem"
+                              x-text="item.status"></span>
+                      </div>
+                      <div class="track-sub">
+                        <span x-text="item.artist"></span> · by <span x-text="item.submitter"></span>
+                        <span x-show="item.duration_s"> · <span x-text="formatDuration(item.duration_s)"></span></span>
+                      </div>
+                    </div>
+                    <div style="display:flex; gap:0.3rem; flex-shrink:0">
+                      <button class="btn secondary" style="padding:0.3rem 0.55rem; font-size:0.8rem"
+                              @click="moveItem(idx, -1)" :disabled="idx === 0">↑</button>
+                      <button class="btn secondary" style="padding:0.3rem 0.55rem; font-size:0.8rem"
+                              @click="moveItem(idx, 1)"
+                              :disabled="idx === editingProgram.items.length - 1">↓</button>
+                      <button class="btn danger" style="padding:0.3rem 0.55rem; font-size:0.8rem"
+                              @click="removeItem(item.item_id)">✕</button>
+                    </div>
+                  </div>
+                </template>
+
+                <div style="margin-top:1rem; display:flex; gap:0.4rem; align-items:flex-end; flex-wrap:wrap">
+                  <div class="form-group" style="flex:1; min-width:200px; margin:0">
+                    <label>Add track</label>
+                    <input type="text" x-model="addTrackQuery" list="program-track-options"
+                           placeholder="Type to filter library…" />
+                    <datalist id="program-track-options">
+                      <template x-for="t in tracks.filter(t => t.status === 'ready')" :key="t.id">
+                        <option :value="t.title + ' — ' + t.artist + ' (' + t.submitter + ')'"
+                                :data-id="t.id"></option>
+                      </template>
+                    </datalist>
+                  </div>
+                  <button class="btn" @click="addTrackFromQuery()">Add</button>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <div x-show="importResult" x-cloak
+               style="margin-top:1rem; padding:0.75rem 1rem; border-radius:6px"
+               :style="importResult && importResult.unmatched.length ? 'background:var(--warn-bg, #3a2c00); color:var(--warn, #ffd16a)' : 'background:var(--surface-2)'">
+            <strong x-text="importResult ? ('Imported ' + importResult.imported + ' items.') : ''"></strong>
+            <template x-if="importResult && importResult.unmatched.length">
+              <div style="margin-top:0.5rem; font-size:0.85rem">
+                <div x-text="importResult.unmatched.length + ' item(s) could not be matched in this library:'"></div>
+                <ul style="margin:0.4rem 0 0 1.2rem">
+                  <template x-for="u in importResult.unmatched" :key="u.position">
+                    <li x-text="u.title + ' — ' + u.artist + ' (' + u.submitter + ')'"></li>
+                  </template>
+                </ul>
+              </div>
+            </template>
+            <button class="btn secondary" style="margin-top:0.5rem; padding:0.3rem 0.7rem; font-size:0.8rem"
+                    @click="importResult = null">Dismiss</button>
           </div>
         </div>
 
@@ -551,6 +700,11 @@
                      x-text="track.error_msg"></div>
               </div>
               <span class="badge" :class="track.status" x-text="track.status"></span>
+              <button class="btn" :class="{ secondary: !track.in_rotation }"
+                      style="padding:0.35rem 0.75rem; font-size:0.8rem"
+                      :title="track.in_rotation ? 'In rotation — click to exclude from rotation/mood' : 'Off rotation — click to include in rotation/mood'"
+                      @click="toggleInRotation(track)"
+                      x-text="track.in_rotation ? 'In rotation' : 'Off rotation'"></button>
               <button class="btn danger" style="padding:0.35rem 0.75rem; font-size:0.8rem"
                       @click="deleteTrack(track.id)">✕</button>
             </div>
@@ -1585,6 +1739,14 @@
         _loaded: false,
         newUserEmail: '',
         newUserName: '',
+        programs: [],
+        activeProgramId: '',
+        editingProgramId: null,
+        editingProgram: null,
+        editingProgramName: '',
+        newProgramName: '',
+        addTrackQuery: '',
+        importResult: null,
 
         get pendingUsers() {
           return this.users.filter(u => u.status === 'pending');
@@ -1613,7 +1775,8 @@
               this.config = await res.json();
               this.authed = true;
               localStorage.setItem('adminToken', this.tokenInput);
-              await Promise.all([this.loadLibrary(), this.loadCookieStatus(), this.loadUsers()]);
+              await Promise.all([this.loadLibrary(), this.loadCookieStatus(), this.loadUsers(), this.loadPrograms()]);
+              this.activeProgramId = this.config.active_program_id ? String(this.config.active_program_id) : '';
             } else {
               this.authError = 'Invalid token.';
               localStorage.removeItem('adminToken');
@@ -1699,10 +1862,248 @@
         async setMode(mode) {
           const res = await this.apiPost('/api/admin/config', { programming_mode: mode });
           if (res.ok) {
-            this.config.programming_mode = mode;
+            await this.refreshConfig();
             this.flash('success', 'Mode set to ' + mode);
           } else {
             this.flash('error', 'Failed to update mode.');
+          }
+        },
+
+        async setProgrammedMode() {
+          if (!this.activeProgramId) {
+            this.flash('error', 'Select an active program first.');
+            return;
+          }
+          const res = await this.apiPost('/api/admin/config', {
+            programming_mode: 'programmed',
+            active_program_id: parseInt(this.activeProgramId, 10),
+          });
+          if (res.ok) {
+            await this.refreshConfig();
+            await this.loadPrograms();
+            this.flash('success', 'Programmed mode active.');
+          } else {
+            const data = await res.json().catch(() => ({}));
+            this.flash('error', data.detail || 'Failed to switch to programmed mode.');
+          }
+        },
+
+        async refreshConfig() {
+          const res = await this.apiGet('/api/admin/config');
+          if (res.ok) {
+            this.config = await res.json();
+            this.activeProgramId = this.config.active_program_id ? String(this.config.active_program_id) : '';
+          }
+        },
+
+        async loadPrograms() {
+          const res = await this.apiGet('/api/admin/programs');
+          if (!res.ok) return;
+          const data = await res.json();
+          this.programs = data.programs;
+          // If the program currently being edited still exists, reload its detail.
+          if (this.editingProgramId && this.programs.find(p => p.id === this.editingProgramId)) {
+            await this.loadProgramDetail(this.editingProgramId);
+          } else if (this.editingProgramId) {
+            this.editingProgramId = null;
+            this.editingProgram = null;
+          }
+        },
+
+        async createProgram() {
+          const name = this.newProgramName.trim();
+          if (!name) return;
+          const res = await this.apiPost('/api/admin/programs', { name });
+          if (res.ok) {
+            this.newProgramName = '';
+            await this.loadPrograms();
+            this.flash('success', 'Program created.');
+          } else {
+            this.flash('error', 'Failed to create program.');
+          }
+        },
+
+        async deleteProgram(programId) {
+          const program = this.programs.find(p => p.id === programId);
+          const label = program ? program.name : 'this program';
+          if (!confirm('Delete "' + label + '"? Items will be removed; tracks remain in the library.')) return;
+          const res = await this.apiFetch('DELETE', '/api/admin/programs/' + programId);
+          if (res.ok) {
+            if (this.editingProgramId === programId) {
+              this.editingProgramId = null;
+              this.editingProgram = null;
+            }
+            await Promise.all([this.loadPrograms(), this.refreshConfig()]);
+            this.flash('success', 'Program deleted.');
+          } else {
+            this.flash('error', 'Failed to delete program.');
+          }
+        },
+
+        async setActiveProgram(programId) {
+          if (!programId) {
+            // Selecting "(none)" doesn't have a server endpoint; only meaningful when leaving programmed mode.
+            return;
+          }
+          const res = await this.apiPost('/api/admin/programs/' + programId + '/activate', {});
+          if (res.ok) {
+            await Promise.all([this.refreshConfig(), this.loadPrograms()]);
+            this.flash('success', 'Active program updated.');
+          } else {
+            const data = await res.json().catch(() => ({}));
+            this.flash('error', data.detail || 'Failed to set active program.');
+            await this.refreshConfig();
+          }
+        },
+
+        async toggleEditProgram(programId) {
+          if (this.editingProgramId === programId) {
+            this.editingProgramId = null;
+            this.editingProgram = null;
+            return;
+          }
+          await this.loadProgramDetail(programId);
+          this.editingProgramId = programId;
+        },
+
+        async loadProgramDetail(programId) {
+          const res = await this.apiGet('/api/admin/programs/' + programId);
+          if (res.ok) {
+            this.editingProgram = await res.json();
+            this.editingProgramName = this.editingProgram.name;
+          }
+        },
+
+        async renameProgram() {
+          const name = this.editingProgramName.trim();
+          if (!name || !this.editingProgramId) return;
+          const res = await fetch('/api/admin/programs/' + this.editingProgramId, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', 'X-Admin-Token': this.tokenInput },
+            body: JSON.stringify({ name }),
+          });
+          if (res.ok) {
+            this.editingProgram = await res.json();
+            this.editingProgramName = this.editingProgram.name;
+            await this.loadPrograms();
+            this.flash('success', 'Renamed.');
+          } else {
+            this.flash('error', 'Rename failed.');
+          }
+        },
+
+        async addTrackFromQuery() {
+          if (!this.editingProgramId) return;
+          const q = this.addTrackQuery;
+          // Find the matching <option> by value to get the data-id attribute
+          const datalist = document.getElementById('program-track-options');
+          let trackId = null;
+          if (datalist) {
+            const opt = Array.from(datalist.options).find(o => o.value === q);
+            if (opt) trackId = opt.dataset.id;
+          }
+          // Fallback: if user typed something that isn't an exact option, ignore
+          if (!trackId) {
+            this.flash('error', 'Pick a track from the list.');
+            return;
+          }
+          const res = await this.apiPost('/api/admin/programs/' + this.editingProgramId + '/items', { track_id: trackId });
+          if (res.ok) {
+            this.editingProgram = await res.json();
+            this.addTrackQuery = '';
+            await this.loadPrograms();
+          } else {
+            this.flash('error', 'Failed to add track.');
+          }
+        },
+
+        async removeItem(itemId) {
+          if (!this.editingProgramId) return;
+          const res = await this.apiFetch('DELETE', '/api/admin/programs/' + this.editingProgramId + '/items/' + itemId);
+          if (res.ok) {
+            this.editingProgram = await res.json();
+            await this.loadPrograms();
+          } else {
+            this.flash('error', 'Failed to remove item.');
+          }
+        },
+
+        async moveItem(idx, delta) {
+          if (!this.editingProgram) return;
+          const items = this.editingProgram.items;
+          const j = idx + delta;
+          if (j < 0 || j >= items.length) return;
+          const ids = items.map(i => i.item_id);
+          [ids[idx], ids[j]] = [ids[j], ids[idx]];
+          const res = await fetch('/api/admin/programs/' + this.editingProgramId + '/items', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', 'X-Admin-Token': this.tokenInput },
+            body: JSON.stringify({ item_ids: ids }),
+          });
+          if (res.ok) {
+            this.editingProgram = await res.json();
+          } else {
+            this.flash('error', 'Reorder failed.');
+          }
+        },
+
+        exportProgram(event, programId) {
+          // The <a download> handles the download; we just need to inject the admin token.
+          // Browsers don't let us set custom headers on plain anchor downloads, so we do a fetch instead.
+          event.preventDefault();
+          fetch('/api/admin/programs/' + programId + '/export', {
+            headers: { 'X-Admin-Token': this.tokenInput },
+          }).then(res => {
+            if (!res.ok) throw new Error('export failed');
+            const disp = res.headers.get('Content-Disposition') || '';
+            const m = disp.match(/filename="([^"]+)"/);
+            const filename = m ? m[1] : 'program.json';
+            return res.blob().then(blob => ({ blob, filename }));
+          }).then(({ blob, filename }) => {
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+          }).catch(() => this.flash('error', 'Export failed.'));
+        },
+
+        async importProgram(event) {
+          const file = event.target.files[0];
+          event.target.value = '';
+          if (!file) return;
+          const form = new FormData();
+          form.append('file', file);
+          const res = await fetch('/api/admin/programs/import', {
+            method: 'POST',
+            headers: { 'X-Admin-Token': this.tokenInput },
+            body: form,
+          });
+          if (res.ok) {
+            this.importResult = await res.json();
+            await this.loadPrograms();
+            this.flash('success', 'Program imported.');
+          } else {
+            const data = await res.json().catch(() => ({}));
+            this.flash('error', data.detail || 'Import failed.');
+          }
+        },
+
+        async toggleInRotation(track) {
+          const next = !track.in_rotation;
+          const res = await fetch('/api/admin/track/' + track.id, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', 'X-Admin-Token': this.tokenInput },
+            body: JSON.stringify({ in_rotation: next }),
+          });
+          if (res.ok) {
+            track.in_rotation = next;
+            this.flash('success', track.title + ' is now ' + (next ? 'in rotation' : 'off rotation') + '.');
+          } else {
+            this.flash('error', 'Failed to update track.');
           }
         },
 


### PR DESCRIPTION
## Summary

Adds a third playback mode (`programmed`) that plays a static, pre-designed sequence for an occasion and auto-reverts to rotation when the playlist ends. Programs are saved as a library — admin can switch between several saved programs (e.g. "Birthday Party", "Christmas Morning"). The AI DJ is suppressed during programmed mode since the order is already deliberate.

A `tracks.in_rotation` flag (default true) lets a track exist in the library but be excluded from rotation/mood — useful for jingles or occasion-only tracks that should only play when the admin programs them.

## Approach

**Schema** — new `programs` and `program_items` tables (CASCADE on track/program delete). New `in_rotation` column on `tracks` migrated with `DEFAULT 1` so existing tracks are unaffected. Three new config keys: `active_program_id`, `program_current_position`, `program_pending_position`.

**Scheduler** — `get_next_track()` short-circuits programmed mode above the DJ block, so DJ logic is never reached. `_pick_programmed_track` plays through items in order, and at end-of-program flips `programming_mode` back to `rotation` and recurses into the rotation pick (avoiding dead air for one polling cycle). `AND in_rotation=1` added to every rotation/mood/cooldown/global-fallback query.

**Programs router** (new `api/routers/programs.py`) — full CRUD, activate, reorder via full-list rewrite, JSON manifest export/import. Imports match by `track_id`, then `title+artist+submitter`, then `title+artist`; unmatched items are reported in the response so the admin knows which placements failed.

**Skip in programmed mode** — Liquidsoap prefetches one track ahead, so a returned item can be flushed by skip before it plays. A new `program_pending_position` marker tracks the in-flight prefetched item. `_liquidsoap_skip` rewinds `program_current_position` to that value before flushing; Liquidsoap's auto-refetch then returns the same item again. `track-started` only clears the marker when the started `track_id` matches the item at the pending position — without this match check, `track-started` for the currently-playing track races the next prefetch (both fire near-simultaneously when Liquidsoap transitions tracks) and can clobber a fresh prefetch marker, breaking later skips.

**Frontend** — third "Programmed" mode button (disabled until an active program is set), Programs admin card with active-program select, create/edit/delete, inline editor (rename, up/down reorder, remove, add-track datalist), per-program export (fetches with admin token then triggers blob download), import via hidden file input with unmatched-items alert. Per-track In rotation / Off rotation toggle in the admin library card.

## Test plan

- [ ] Migrations apply cleanly to existing DB; `tracks.in_rotation` defaults to 1 for existing rows
- [ ] Toggle a track off rotation → confirm it does not appear in rotation or mood mode
- [ ] Create a program with a mix of in-rotation, off-rotation, and duplicated tracks → activate → switch to programmed mode → verify each item plays in declared order
- [ ] At end of program, mode auto-reverts to `rotation` and a rotation track plays
- [ ] AI DJ is suppressed while in programmed mode (no `DJ: triggering generation` in logs); resumes after auto-revert
- [ ] Skip during programmed mode does NOT silently lose the prefetched item — the previously-prefetched track plays after the skip-interrupted track ends
- [ ] Skip a few times rapidly, including just after a track-started; verify each skipped item plays exactly once and order is preserved
- [ ] Export a program → delete it → import the JSON → all items match
- [ ] Import a manifest with one bogus title → program created with the rest, response lists the missing item
- [ ] Validation: switching to programmed without `active_program_id` returns 400; activating an empty program returns 400
- [ ] Edit the active program mid-play (add/remove/reorder); subsequent skip behaves correctly (no rewind to a stale position)
- [ ] Delete the currently active program → mode auto-reverts to rotation