### PR TITLE
ci: bump configure-aws-credentials to v5 for Node 24 runtime

### DIFF
--- a/.github/workflows/nightly-rebuild.yml
+++ b/.github/workflows/nightly-rebuild.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.RADIO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.RADIO_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Problem

The `nightly-rebuild.yml` workflow uses `aws-actions/configure-aws-credentials@v4`, which runs on Node.js 20. GitHub Actions deprecation notice: Node 20 actions are **forced to run on Node 24 starting 2026-06-16**, and Node 20 is **removed from runners on 2026-09-16**. The June 15 nightly-rebuild run surfaced this as a warning.

## Approach

Bump the action to `@v5`, which is built for the Node 24 runtime. This is the workflow's only AWS auth step and the only use of the action in the repo. No behavioral change — `v5` takes the same `aws-access-key-id` / `aws-secret-access-key` / `aws-region` inputs.

This is unrelated to but discovered alongside the June 15 incident where the nightly-rebuild failed due to AWS account suspension (expired free credits → all IAM keys rejected with `InvalidClientTokenId` + the EC2 instance stopped). That was resolved by restoring billing, starting the instance, and bringing nginx back up; the workflow itself is healthy again.